### PR TITLE
feat(embedding): add embedding pipeline and qdrant CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,9 @@ OPENAI_API_KEY=sk-your-key-here
 # AZURE_OPENAI_DEPLOYMENT=
 
 # Qdrant
-QDRANT_HOST=localhost
-QDRANT_PORT=6333
+QDRANT_URL=http://localhost:6333
 QDRANT_API_KEY=  # Optional, for cloud
+QDRANT_TIMEOUT=10
 
 # Redis
 REDIS_URL=redis://localhost:6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv run ruff check src/ tests/ --output-format=github
 
       - name: Run Flake8
-        run: uv run flake8 src/ tests/ --max-line-length=100 --ignore=E501,W503
+        run: uv run flake8 src/ tests/ --max-line-length=100 --ignore=E501,W503,E203
 
       - name: Run Black (formatter check)
         run: uv run black --check src/ tests/
@@ -49,6 +49,8 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    env:
+      QDRANT_URL: http://localhost:6333
     services:
       qdrant:
         image: qdrant/qdrant:latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,12 @@ repos:
       - id: black
         language_version: python3.11
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=100", "--ignore=E501,W503,E203"]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,6 +390,31 @@ make docker-up    # Avvia Qdrant + Redis
 
 ---
 
+## Code Style - AI Agent Guidelines
+
+> **alwaysApply: true** - Queste regole si applicano SEMPRE quando un AI agent genera codice.
+
+### Comments
+- **Don't** add comments that restate what code does
+- **Don't** add JSDoc/docstrings unless required by the codebase (in questo progetto: solo su funzioni pubbliche)
+- Only comment **why**, not **what**
+- **No** "Added by Claude" or attribution comments
+- **No** placeholder TODOs like `// TODO: implement`
+
+### Don't Over-Engineer
+- No helper functions for one-time operations
+- No abstractions for single use cases
+- No extra error handling "just in case"
+- No backwards-compatibility shims when changing code directly works
+
+### Stay Focused
+- Only modify code relevant to the task
+- No drive-by refactoring of unrelated code
+- No reformatting lines you didn't change
+- No adding type annotations where inference works (in questo progetto: type hints richiesti su funzioni pubbliche, opzionali su variabili locali)
+
+---
+
 ## References
 
 - [CONTRIBUTING.md](docs/CONTRIBUTING.md) - Git workflow

--- a/scripts/embed_batch.py
+++ b/scripts/embed_batch.py
@@ -1,0 +1,139 @@
+"""CLI script to embed and index CVs in batch into Qdrant."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from src.core.embedding.pipeline import EmbeddingPipeline
+from src.core.parser import parse_docx
+from src.core.skills import SkillExtractor, load_skill_dictionary
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Embed and index a batch of CV DOCX files into Qdrant.",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Directory containing CV DOCX files.",
+    )
+    parser.add_argument(
+        "--dictionary",
+        type=Path,
+        default=Path("data/skills_dictionary.yaml"),
+        help="Path to the skills dictionary YAML.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Number of CV files to process per batch.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute embeddings without writing to Qdrant.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level.",
+    )
+    return parser
+
+
+def _iter_docx_files(directory: Path) -> list[Path]:
+    """Collect DOCX files from a directory tree."""
+    if not directory.exists():
+        return []
+    return sorted(directory.rglob("*.docx"))
+
+
+def _chunked(items: list[Path], batch_size: int) -> Iterable[list[Path]]:
+    """Yield items in batches."""
+    if batch_size <= 0:
+        return []
+    for i in range(0, len(items), batch_size):
+        yield items[i : i + batch_size]
+
+
+def main() -> int:
+    """Run the batch CV embedding pipeline."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    input_dir: Path = args.input_dir
+    if not input_dir.exists():
+        logger.error("Input directory does not exist: %s", input_dir)
+        return 1
+
+    dictionary_path: Path = args.dictionary
+    if not dictionary_path.exists():
+        logger.error("Skills dictionary not found: %s", dictionary_path)
+        return 1
+
+    cv_files = _iter_docx_files(input_dir)
+    if not cv_files:
+        logger.warning("No DOCX files found in: %s", input_dir)
+        return 0
+
+    dictionary = load_skill_dictionary(dictionary_path)
+    extractor = SkillExtractor(dictionary)
+    pipeline = EmbeddingPipeline()
+
+    processed = 0
+    failed = 0
+    totals = {"cv_skills": 0, "cv_experiences": 0, "total": 0}
+    errors: list[dict[str, str]] = []
+
+    for batch in _chunked(cv_files, args.batch_size):
+        logger.info("Processing batch with %d CVs", len(batch))
+        for cv_path in batch:
+            try:
+                parsed_cv = parse_docx(cv_path)
+                skill_result = extractor.extract(parsed_cv)
+                result = pipeline.process_cv(parsed_cv, skill_result, dry_run=args.dry_run)
+                totals["cv_skills"] += result["cv_skills"]
+                totals["cv_experiences"] += result["cv_experiences"]
+                totals["total"] += result["total"]
+                processed += 1
+            except Exception as exc:  # noqa: BLE001 - surface errors per CV
+                failed += 1
+                logger.exception("Failed processing CV: %s", cv_path)
+                errors.append({"file": str(cv_path), "error": str(exc)})
+
+    payload = {
+        "input_dir": str(input_dir),
+        "dry_run": args.dry_run,
+        "processed": processed,
+        "failed": failed,
+        "totals": totals,
+        "errors": errors,
+    }
+
+    if args.pretty:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps(payload, ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/embed_cv.py
+++ b/scripts/embed_cv.py
@@ -1,0 +1,95 @@
+"""CLI script to embed and index a single CV into Qdrant."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from src.core.embedding.pipeline import EmbeddingPipeline
+from src.core.parser import parse_docx
+from src.core.skills import SkillExtractor, load_skill_dictionary
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Embed and index a single CV DOCX into Qdrant.",
+    )
+    parser.add_argument(
+        "--cv",
+        type=Path,
+        required=True,
+        help="Path to the CV DOCX file.",
+    )
+    parser.add_argument(
+        "--dictionary",
+        type=Path,
+        default=Path("data/skills_dictionary.yaml"),
+        help="Path to the skills dictionary YAML.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute embeddings without writing to Qdrant.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level.",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the single CV embedding pipeline."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    cv_path: Path = args.cv
+    if not cv_path.exists():
+        logger.error("CV file does not exist: %s", cv_path)
+        return 1
+    if cv_path.suffix.lower() != ".docx":
+        logger.warning("CV file extension is not .docx: %s", cv_path)
+
+    dictionary_path: Path = args.dictionary
+    if not dictionary_path.exists():
+        logger.error("Skills dictionary not found: %s", dictionary_path)
+        return 1
+
+    parsed_cv = parse_docx(cv_path)
+    dictionary = load_skill_dictionary(dictionary_path)
+    extractor = SkillExtractor(dictionary)
+    skill_result = extractor.extract(parsed_cv)
+
+    pipeline = EmbeddingPipeline()
+    result = pipeline.process_cv(parsed_cv, skill_result, dry_run=args.dry_run)
+
+    payload = {
+        "cv_id": parsed_cv.metadata.cv_id,
+        "file_name": parsed_cv.metadata.file_name,
+        "dry_run": args.dry_run,
+        "result": result,
+    }
+
+    if args.pretty:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps(payload, ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/embedding/__init__.py
+++ b/src/core/embedding/__init__.py
@@ -1,0 +1,15 @@
+"""Embedding pipeline module exports."""
+
+from __future__ import annotations
+
+from src.core.embedding.pipeline import EmbeddingPipeline
+from src.core.embedding.schemas import BatchEmbeddingResult, EmbeddingResult
+from src.core.embedding.service import EmbeddingService, OpenAIEmbeddingService
+
+__all__ = [
+    "BatchEmbeddingResult",
+    "EmbeddingPipeline",
+    "EmbeddingResult",
+    "EmbeddingService",
+    "OpenAIEmbeddingService",
+]

--- a/src/core/embedding/pipeline.py
+++ b/src/core/embedding/pipeline.py
@@ -1,0 +1,272 @@
+"""Embedding pipeline orchestration for CV indexing."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from qdrant_client import QdrantClient, models
+
+from src.core.embedding.service import EmbeddingService, OpenAIEmbeddingService
+from src.core.parser.schemas import ExperienceItem, ParsedCV
+from src.core.skills.schemas import NormalizedSkill, SkillExtractionResult
+from src.services.qdrant.client import get_qdrant_client
+from src.services.qdrant.collections import ensure_collections
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExperienceCandidate:
+    index: int
+    experience: ExperienceItem
+    text: str
+
+
+class EmbeddingPipeline:
+    """Orchestrate CV embedding and indexing in Qdrant.
+
+    Args:
+        embedding_service: Service used to generate embeddings.
+        qdrant_client: Optional Qdrant client instance.
+    """
+
+    def __init__(
+        self,
+        embedding_service: EmbeddingService | None = None,
+        qdrant_client: QdrantClient | None = None,
+    ) -> None:
+        self._embedding_service = embedding_service or OpenAIEmbeddingService()
+        self._qdrant_client = qdrant_client or get_qdrant_client()
+        ensure_collections(self._qdrant_client)
+
+    def process_cv(
+        self,
+        parsed_cv: ParsedCV,
+        skill_result: SkillExtractionResult,
+        *,
+        dry_run: bool = False,
+    ) -> dict[str, int]:
+        """Process a parsed CV and upsert embeddings into Qdrant.
+
+        Args:
+            parsed_cv: Parsed CV object from the parser.
+            skill_result: Skill extraction result for the CV.
+            dry_run: When True, compute points without upserting.
+
+        Returns:
+            A dict with counts of upserted points.
+        """
+        cv_id = parsed_cv.metadata.cv_id
+        created_at = datetime.utcnow()
+
+        skills_points = self._build_skills_points(
+            parsed_cv=parsed_cv,
+            skill_result=skill_result,
+            created_at=created_at,
+        )
+        experience_points = self._build_experience_points(
+            parsed_cv=parsed_cv,
+            skill_result=skill_result,
+            created_at=created_at,
+        )
+
+        total_points = len(skills_points) + len(experience_points)
+        if total_points == 0:
+            logger.warning("No points to index for CV '%s'", cv_id)
+            return {"cv_skills": 0, "cv_experiences": 0, "total": 0}
+
+        if dry_run:
+            logger.info(
+                "Dry-run enabled for CV '%s' (%d points)",
+                cv_id,
+                total_points,
+            )
+            return {
+                "cv_skills": len(skills_points),
+                "cv_experiences": len(experience_points),
+                "total": total_points,
+            }
+
+        if skills_points:
+            self._qdrant_client.upsert(
+                collection_name="cv_skills",
+                points=skills_points,
+                wait=True,
+            )
+
+        if experience_points:
+            self._qdrant_client.upsert(
+                collection_name="cv_experiences",
+                points=experience_points,
+                wait=True,
+            )
+
+        logger.info(
+            "Indexed CV '%s': %d points",
+            cv_id,
+            total_points,
+        )
+        return {
+            "cv_skills": len(skills_points),
+            "cv_experiences": len(experience_points),
+            "total": total_points,
+        }
+
+    def _build_skills_points(
+        self,
+        parsed_cv: ParsedCV,
+        skill_result: SkillExtractionResult,
+        created_at: datetime,
+    ) -> list[models.PointStruct]:
+        cv_id = parsed_cv.metadata.cv_id
+        if not skill_result.normalized_skills:
+            logger.warning("CV '%s' has no skills, skipping cv_skills", cv_id)
+            return []
+
+        normalized_skills = _dedupe_skills(skill_result.normalized_skills)
+        if not normalized_skills:
+            logger.warning("CV '%s' has empty skill list, skipping cv_skills", cv_id)
+            return []
+
+        skills_text = ", ".join(normalized_skills).strip()
+        if not skills_text:
+            logger.warning("CV '%s' has empty skill text, skipping cv_skills", cv_id)
+            return []
+
+        vector = self._embedding_service.embed(skills_text)
+
+        payload = {
+            "cv_id": cv_id,
+            "section_type": "skills",
+            "normalized_skills": normalized_skills,
+            "skill_domain": _get_primary_domain(skill_result.normalized_skills),
+            "seniority_bucket": "unknown",
+            "dictionary_version": skill_result.dictionary_version,
+            "created_at": created_at,
+        }
+        point_id = _generate_point_id(cv_id, "skills")
+        return [models.PointStruct(id=point_id, vector=vector, payload=payload)]
+
+    def _build_experience_points(
+        self,
+        parsed_cv: ParsedCV,
+        skill_result: SkillExtractionResult,
+        created_at: datetime,
+    ) -> list[models.PointStruct]:
+        cv_id = parsed_cv.metadata.cv_id
+        candidates = _collect_experience_texts(parsed_cv.experiences)
+
+        if not candidates:
+            logger.warning("CV '%s' has no experience descriptions to embed", cv_id)
+            return []
+
+        related_skills = _dedupe_skills(skill_result.normalized_skills)
+
+        points: list[models.PointStruct] = []
+        for batch in _chunked(candidates, _get_batch_size()):
+            texts = [item.text for item in batch]
+            vectors = self._embedding_service.embed_batch(texts)
+
+            if len(vectors) != len(texts):
+                logger.warning(
+                    "Embedding batch size mismatch for CV '%s': %d texts, %d vectors",
+                    cv_id,
+                    len(texts),
+                    len(vectors),
+                )
+
+            for candidate, vector in zip(batch, vectors, strict=False):
+                experience: ExperienceItem = candidate.experience
+                index: int = candidate.index
+                point_id = _generate_experience_id(cv_id, index)
+
+                payload = {
+                    "cv_id": cv_id,
+                    "section_type": "experience",
+                    "related_skills": related_skills,
+                    "experience_years": _calc_experience_years(experience),
+                    "created_at": created_at,
+                }
+                points.append(models.PointStruct(id=point_id, vector=vector, payload=payload))
+
+        return points
+
+
+def _get_primary_domain(skills: Iterable[NormalizedSkill]) -> str:
+    """Return the most common domain among normalized skills."""
+    domain_list = [skill.domain for skill in skills if skill.domain]
+    if not domain_list:
+        return "unknown"
+    most_common = Counter(domain_list).most_common(1)
+    return most_common[0][0] if most_common else "unknown"
+
+
+def _dedupe_skills(skills: Iterable[NormalizedSkill]) -> list[str]:
+    """Return unique canonical skills preserving order."""
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for skill in skills:
+        canonical = skill.canonical.strip().lower()
+        if not canonical or canonical in seen:
+            continue
+        seen.add(canonical)
+        deduped.append(canonical)
+    return deduped
+
+
+def _chunked(
+    items: list[ExperienceCandidate],
+    batch_size: int,
+) -> Iterable[list[ExperienceCandidate]]:
+    """Yield items in batches."""
+    if batch_size <= 0:
+        return
+    for i in range(0, len(items), batch_size):
+        yield items[i : i + batch_size]
+
+
+def _get_batch_size() -> int:
+    """Return embedding batch size from environment."""
+    raw = os.getenv("EMBEDDING_BATCH_SIZE", "100")
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 100
+    return max(1, value)
+
+
+def _calc_experience_years(experience: ExperienceItem) -> int | None:
+    """Calculate experience years when dates are available."""
+    if experience.start_date and experience.end_date:
+        delta_days = (experience.end_date - experience.start_date).days
+        return delta_days // 365 if delta_days >= 0 else None
+    if experience.start_date and experience.is_current:
+        delta_days = (date.today() - experience.start_date).days
+        return delta_days // 365 if delta_days >= 0 else None
+    return None
+
+
+def _collect_experience_texts(experiences: list[ExperienceItem]) -> list[ExperienceCandidate]:
+    """Collect experience descriptions for embedding."""
+    collected: list[ExperienceCandidate] = []
+    for index, experience in enumerate(experiences):
+        text = experience.description.strip() if experience.description else ""
+        if not text:
+            continue
+        collected.append(ExperienceCandidate(index=index, experience=experience, text=text))
+    return collected
+
+
+def _generate_point_id(cv_id: str, section: str) -> str:
+    """Generate deterministic point IDs for idempotency."""
+    return f"{cv_id}_{section}"
+
+
+def _generate_experience_id(cv_id: str, index: int) -> str:
+    """Generate deterministic experience IDs for idempotency."""
+    return f"{cv_id}_exp_{index}"

--- a/src/core/embedding/schemas.py
+++ b/src/core/embedding/schemas.py
@@ -1,0 +1,45 @@
+"""Pydantic schemas for embedding results."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class EmbeddingResult(BaseModel):
+    """Embedding result for a single text input.
+
+    Args:
+        text: Original text used to generate the embedding.
+        vector: Embedding vector.
+        model: Embedding model name.
+        dimensions: Expected embedding vector size.
+    """
+
+    text: str
+    vector: list[float]
+    model: str
+    dimensions: int = Field(..., ge=1)
+
+
+class BatchEmbeddingResult(BaseModel):
+    """Embedding result for a batch of texts.
+
+    Args:
+        items: Embedding results for successfully processed texts.
+        failed_texts: Texts that failed to embed.
+        model: Embedding model name.
+        dimensions: Expected embedding vector size.
+    """
+
+    items: list[EmbeddingResult] = Field(default_factory=list)
+    failed_texts: list[str] = Field(default_factory=list)
+    model: str
+    dimensions: int = Field(..., ge=1)
+
+    @property
+    def total(self) -> int:
+        """Return total number of inputs (success + failed)."""
+        return len(self.items) + len(self.failed_texts)
+
+
+__all__ = ["BatchEmbeddingResult", "EmbeddingResult"]

--- a/src/core/embedding/service.py
+++ b/src/core/embedding/service.py
@@ -1,0 +1,154 @@
+"""Embedding service implementations."""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import cast
+
+from openai import OpenAI
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+
+def _get_env(name: str, default: str | None = None) -> str | None:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+class EmbeddingService(ABC):
+    """Abstract interface for embedding generation."""
+
+    @property
+    @abstractmethod
+    def model(self) -> str:
+        """Return the embedding model name."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def dimensions(self) -> int:
+        """Return the embedding vector size."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def embed(self, text: str) -> list[float]:
+        """Generate an embedding for a single text input.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            Embedding vector.
+
+        Raises:
+            ValueError: If the input text is empty.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def embed_batch(self, texts: Iterable[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of texts.
+
+        Args:
+            texts: Iterable of input texts.
+
+        Returns:
+            List of embedding vectors aligned with input order.
+        """
+        raise NotImplementedError
+
+
+class OpenAIEmbeddingService(EmbeddingService):
+    """OpenAI embedding service with retry."""
+
+    def __init__(self, client: OpenAI | None = None) -> None:
+        """Initialize the embedding service.
+
+        Args:
+            client: Optional OpenAI client instance.
+        """
+        self._client = client or OpenAI()
+        self._model = (
+            _get_env("EMBEDDING_MODEL", "text-embedding-3-small") or "text-embedding-3-small"
+        )
+        dims_raw = _get_env("EMBEDDING_DIMENSIONS", "1536")
+        self._dimensions = int(dims_raw) if dims_raw else 1536
+
+    @property
+    def model(self) -> str:
+        """Return the configured embedding model name."""
+        return self._model
+
+    @property
+    def dimensions(self) -> int:
+        """Return the expected embedding vector size."""
+        return self._dimensions
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=10))
+    def embed(self, text: str) -> list[float]:
+        """Generate an embedding for a single text input.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            Embedding vector.
+
+        Raises:
+            ValueError: If the input text is empty.
+        """
+        cleaned = text.strip()
+        if not cleaned:
+            raise ValueError("Text for embedding cannot be empty")
+
+        logger.debug("Generating embedding with model '%s'", self._model)
+        response = self._client.embeddings.create(model=self._model, input=cleaned)
+        vector = cast(list[float], response.data[0].embedding)
+        self._validate_dimensions(vector)
+        return vector
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=10))
+    def embed_batch(self, texts: Iterable[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of texts.
+
+        Args:
+            texts: Iterable of input texts.
+
+        Returns:
+            List of embedding vectors aligned with input order.
+
+        Raises:
+            ValueError: If there are no valid texts to embed.
+        """
+        cleaned_texts = [text.strip() for text in texts if text and text.strip()]
+        if not cleaned_texts:
+            raise ValueError("No valid texts provided for embedding")
+
+        logger.debug("Generating batch embeddings with model '%s'", self._model)
+        response = self._client.embeddings.create(model=self._model, input=cleaned_texts)
+        vectors = [cast(list[float], item.embedding) for item in response.data]
+        for vector in vectors:
+            self._validate_dimensions(vector)
+        return vectors
+
+    def _validate_dimensions(self, vector: list[float]) -> None:
+        """Validate embedding vector size.
+
+        Args:
+            vector: Embedding vector to validate.
+        """
+        if len(vector) != self._dimensions:
+            logger.warning(
+                "Embedding dimension mismatch. Expected %d, got %d",
+                self._dimensions,
+                len(vector),
+            )
+
+
+__all__ = ["EmbeddingService", "OpenAIEmbeddingService"]

--- a/src/services/qdrant/collections.py
+++ b/src/services/qdrant/collections.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 
 from qdrant_client import QdrantClient, models
 
-DEFAULT_VECTOR_SIZE = int(os.getenv("QDRANT_VECTOR_SIZE", "1536"))
+DEFAULT_VECTOR_SIZE = int(os.getenv("EMBEDDING_DIMENSIONS", "1536"))
 DEFAULT_DISTANCE = models.Distance.COSINE
 
 

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.embedding.pipeline import EmbeddingPipeline
+from src.core.parser.schemas import CVMetadata, ExperienceItem, ParsedCV, SkillSection
+from src.core.skills.schemas import NormalizedSkill, SkillExtractionResult
+
+
+@pytest.fixture(autouse=True)
+def _stub_ensure_collections(monkeypatch):
+    monkeypatch.setattr("src.core.embedding.pipeline.ensure_collections", lambda *_: None)
+
+
+class DummyEmbeddingService:
+    def __init__(self) -> None:
+        self._model = "text-embedding-3-small"
+        self._dimensions = 3
+        self.embed_calls: list[str] = []
+        self.embed_batch_calls: list[list[str]] = []
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    def embed(self, text: str) -> list[float]:
+        self.embed_calls.append(text)
+        return [0.1, 0.2, 0.3]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self.embed_batch_calls.append(texts)
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+
+def _make_parsed_cv() -> ParsedCV:
+    metadata = CVMetadata(cv_id="cv-123", file_name="cv.docx")
+    skills = SkillSection(raw_text="Python, FastAPI", skill_keywords=["Python", "FastAPI"])
+    experiences = [
+        ExperienceItem(
+            company="Acme",
+            role="Engineer",
+            start_date=date(2020, 1, 1),
+            end_date=date(2022, 1, 1),
+            description="Built APIs",
+            is_current=False,
+        ),
+        ExperienceItem(
+            company="Beta",
+            role="Senior Engineer",
+            start_date=date(2022, 2, 1),
+            end_date=None,
+            description="Leading backend team",
+            is_current=True,
+        ),
+    ]
+    return ParsedCV(
+        metadata=metadata,
+        skills=skills,
+        experiences=experiences,
+        education=[],
+        certifications=[],
+        raw_text="",
+    )
+
+
+def _make_skill_result() -> SkillExtractionResult:
+    skills = [
+        NormalizedSkill(
+            original="Python",
+            canonical="python",
+            domain="backend",
+            confidence=1.0,
+            match_type="exact",
+        ),
+        NormalizedSkill(
+            original="FastAPI",
+            canonical="fastapi",
+            domain="backend",
+            confidence=1.0,
+            match_type="exact",
+        ),
+        NormalizedSkill(
+            original="PostgreSQL",
+            canonical="postgresql",
+            domain="data",
+            confidence=1.0,
+            match_type="exact",
+        ),
+    ]
+    return SkillExtractionResult(
+        cv_id="cv-123",
+        normalized_skills=skills,
+        unknown_skills=[],
+        dictionary_version="1.0.0",
+    )
+
+
+def test_process_cv__dry_run__returns_counts_and_skips_upsert(monkeypatch):
+    parsed_cv = _make_parsed_cv()
+    skill_result = _make_skill_result()
+    embedding_service = DummyEmbeddingService()
+    qdrant_client = MagicMock()
+
+    pipeline = EmbeddingPipeline(
+        embedding_service=embedding_service,
+        qdrant_client=qdrant_client,
+    )
+
+    result = pipeline.process_cv(parsed_cv, skill_result, dry_run=True)
+
+    assert result["cv_skills"] == 1
+    assert result["cv_experiences"] == 2
+    assert result["total"] == 3
+    qdrant_client.upsert.assert_not_called()
+
+
+def test_process_cv__no_skills__skips_cv_skills(monkeypatch):
+    parsed_cv = _make_parsed_cv()
+    skill_result = SkillExtractionResult(
+        cv_id="cv-123",
+        normalized_skills=[],
+        unknown_skills=["x"],
+        dictionary_version="1.0.0",
+    )
+    embedding_service = DummyEmbeddingService()
+    qdrant_client = MagicMock()
+
+    pipeline = EmbeddingPipeline(
+        embedding_service=embedding_service,
+        qdrant_client=qdrant_client,
+    )
+
+    result = pipeline.process_cv(parsed_cv, skill_result, dry_run=True)
+
+    assert result["cv_skills"] == 0
+    assert result["cv_experiences"] == 2
+    assert result["total"] == 2
+    assert embedding_service.embed_calls == []
+
+
+def test_process_cv__upsert_payloads__include_expected_fields(monkeypatch):
+    parsed_cv = _make_parsed_cv()
+    skill_result = _make_skill_result()
+    embedding_service = DummyEmbeddingService()
+    qdrant_client = MagicMock()
+
+    pipeline = EmbeddingPipeline(
+        embedding_service=embedding_service,
+        qdrant_client=qdrant_client,
+    )
+
+    result = pipeline.process_cv(parsed_cv, skill_result, dry_run=False)
+
+    assert result["total"] == 3
+    assert qdrant_client.upsert.call_count == 2
+
+    cv_skills_call = qdrant_client.upsert.call_args_list[0]
+    cv_experiences_call = qdrant_client.upsert.call_args_list[1]
+
+    cv_skills_points = cv_skills_call.kwargs["points"]
+    assert len(cv_skills_points) == 1
+    cv_skills_payload = cv_skills_points[0].payload
+    assert cv_skills_payload["cv_id"] == "cv-123"
+    assert cv_skills_payload["section_type"] == "skills"
+    assert cv_skills_payload["dictionary_version"] == "1.0.0"
+    assert cv_skills_payload["skill_domain"] == "backend"
+    assert cv_skills_payload["seniority_bucket"] == "unknown"
+    assert isinstance(cv_skills_payload["created_at"], datetime)
+
+    cv_exp_points = cv_experiences_call.kwargs["points"]
+    assert len(cv_exp_points) == 2
+    for payload in (point.payload for point in cv_exp_points):
+        assert payload["cv_id"] == "cv-123"
+        assert payload["section_type"] == "experience"
+        assert isinstance(payload["created_at"], datetime)
+
+    experience_years = [point.payload["experience_years"] for point in cv_exp_points]
+    assert experience_years[0] == 2
+    assert experience_years[1] >= 0
+
+
+def test_process_cv__dedupes_skills_in_payload(monkeypatch):
+    parsed_cv = _make_parsed_cv()
+    skills = [
+        NormalizedSkill(
+            original="Python",
+            canonical="python",
+            domain="backend",
+            confidence=1.0,
+            match_type="exact",
+        ),
+        NormalizedSkill(
+            original="PYTHON",
+            canonical="python",
+            domain="backend",
+            confidence=1.0,
+            match_type="exact",
+        ),
+    ]
+    skill_result = SkillExtractionResult(
+        cv_id="cv-123",
+        normalized_skills=skills,
+        unknown_skills=[],
+        dictionary_version="1.0.0",
+    )
+    embedding_service = DummyEmbeddingService()
+    qdrant_client = MagicMock()
+
+    pipeline = EmbeddingPipeline(
+        embedding_service=embedding_service,
+        qdrant_client=qdrant_client,
+    )
+
+    pipeline.process_cv(parsed_cv, skill_result, dry_run=False)
+
+    cv_skills_points = qdrant_client.upsert.call_args_list[0].kwargs["points"]
+    payload = cv_skills_points[0].payload
+    assert payload["normalized_skills"] == ["python"]


### PR DESCRIPTION
## Summary
- add core embedding pipeline with OpenAI service, batching, and idempotent Qdrant upserts
- add CLI scripts for single and batch CV embedding
- add embedding pipeline unit tests
- update Qdrant env/collections usage and align docs
- configure CI to run tests with a Qdrant service container

## Testing
- `uv run pytest tests/test_embedding_pipeline.py`
- `make test`