### PR TITLE
Docs: update user stories and ignore celerybeat state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tests/fixtures/sample_cvs/campione/
 qdrant_storage/
 redis_data/
 storage/
+celerybeat-schedule*
 
 # Logs
 logs/


### PR DESCRIPTION
## Summary
- update user stories documentation
- ignore Celery Beat schedule state files

## Testing
- not applicable (docs only)