### PR TITLE
feat(workflows): add declarative scraper orchestration

### DIFF
--- a/.github/copilot_instructions.md
+++ b/.github/copilot_instructions.md
@@ -190,6 +190,7 @@ class CVMetadata(BaseModel):
 ```
 
 #### Docstrings (Google Style)
+Docstring richieste solo per funzioni pubbliche.
 ```python
 def extract_skills(text: str, dictionary: SkillDictionary) -> list[NormalizedSkill]:
     """Estrae e normalizza le skill da un testo.
@@ -504,7 +505,7 @@ class TestCVParser:
 - [ ] `make lint` - Verifica linting
 - [ ] `make test` - Esegui test
 - [ ] Type hints su tutte le funzioni pubbliche
-- [ ] Docstring su classi e funzioni pubbliche
+- [ ] Docstring su funzioni pubbliche
 
 ### Before PR
 - [ ] `make preflight` - Tutti i check passano
@@ -615,7 +616,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     openai_api_key: str
-    qdrant_url: str = "http://localhost:6333"
+    qdrant_url: str
 
     model_config = {"env_file": ".env"}
 ```
@@ -623,12 +624,13 @@ class Settings(BaseSettings):
 ### Input Validation
 ```python
 # ✅ Valida sempre gli input
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 class CVUploadRequest(BaseModel):
     file_name: str
 
-    @validator("file_name")
+    @field_validator("file_name")
+    @classmethod
     def validate_extension(cls, v):
         if not v.endswith(".docx"):
             raise ValueError("Only .docx files are supported")
@@ -651,7 +653,7 @@ logger.info("Processing request for user_id: '%s'", user_id)
 
 ### Code Quality
 - [ ] Type hints presenti e corretti
-- [ ] Docstring su funzioni/classi pubbliche
+- [ ] Docstring su funzioni pubbliche
 - [ ] Nessun magic number
 - [ ] Error handling appropriato
 - [ ] Logging strutturato

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -113,7 +113,7 @@ async def health():
 
 ### Import Organization
 
-**Regola**: Importare moduli, non nomi. Eccezioni: `typing` e tipi comuni.
+**Regola**: Importare moduli, non nomi. Eccezioni: `typing` e tipi comuni; sono ammessi import diretti da FastAPI/Pydantic (es. `APIRouter`, `HTTPException`, `BaseModel`) quando migliorano la leggibilità.
 
 ```python
 # ✅ Good: Import organizzati correttamente
@@ -304,6 +304,7 @@ def search_profiles(query_embedding, filters=None, limit=10):
 ```
 
 ### Docstring (Google Style)
+Docstring richieste solo per funzioni pubbliche.
 
 ```python
 def normalize_skill(
@@ -584,7 +585,7 @@ class SkillSearchRequest(BaseModel):
 
 ### Qualità Codice
 - [ ] Type hints su tutte le funzioni pubbliche
-- [ ] Docstring su classi e funzioni pubbliche (Google style)
+- [ ] Docstring su funzioni pubbliche (Google style)
 - [ ] Nessun magic number/string
 - [ ] Import organizzati (stdlib → third-party → local)
 - [ ] Metodi privati con prefisso `_` se uso interno

--- a/README.md
+++ b/README.md
@@ -438,7 +438,10 @@ profilebot/
 - [Technical Debt — Ingestion Readiness](docs/technical_debpt.md)
 - [Analisi Preliminare](docs/analisi_preliminare.md)
 - [Guida Formato CV](docs/cv_format_guide.md)
-- [Appendice Tecnica - Indexing](docs/Appendice%20tecnica%20—%20Indexing.md)
+- [Guida Formato Availability](docs/availability_format_guide.md)
+- [Workflow res_id](docs/res_id-workflow.md)
+- [Checklist User Stories](docs/US_CHECKLIST_TEMPLATE.md)
+- [Appendice Tecnica - Indexing](docs/appendice_tecnica_indexing.md)
 - [Team Structure](docs/TEAM_STRUCTURE.md)
 
 ---

--- a/config/workflows/res_id_workflow.yaml
+++ b/config/workflows/res_id_workflow.yaml
@@ -1,0 +1,21 @@
+version: 1
+workflow_id: res_id_ingestion
+schedule: "0 */4 * * *"
+
+nodes:
+  - id: fetch_res_ids
+    task: src.services.scraper.tasks.scraper_inside_refresh_task
+
+  - id: inside_fanout
+    task: src.services.workflows.tasks.run_workflow_fanout_task
+    depends_on: [fetch_res_ids]
+    fanout:
+      source: redis:profilebot:scraper:inside:res_ids
+      task: src.services.scraper.tasks.scraper_inside_refresh_item_task
+      parameter_name: res_id
+
+  - id: export_availability
+    task: src.services.scraper.tasks.scraper_availability_csv_refresh_task
+
+  - id: export_reskilling
+    task: src.services.scraper.tasks.scraper_reskilling_csv_refresh_task

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -87,6 +87,23 @@
 
 ---
 
+### US-016: Orchestrazione Ingestion Scraper (DAG config)
+**Come** sistema
+**Voglio** definire un workflow dichiarativo per le sorgenti scraper
+**Per** aggiungere nuove fonti senza modificare l’orchestrazione
+
+**Acceptance Criteria:**
+- [ ] Workflow definito in JSON/YAML con nodi e dipendenze
+- [ ] Loader con validazione schema (Pydantic)
+- [ ] Runner che converte il DAG in primitive Celery
+- [ ] Schedule ogni 4h collegata al workflow
+- [ ] Mapping nodi → task Celery esistenti
+
+**Story Points:** 5
+**Priority:** P1 - High
+
+---
+
 ## Epic 3: Search & Matching
 > Funzionalità di ricerca e matching profili
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -156,6 +156,19 @@ Una User Story è **DONE** quando:
 
 ---
 
+## Workflow Configuration Updates
+
+Quando modifichi o introduci nuovi workflow (JSON/YAML):
+
+- documenta il nodo e il relativo task Celery nel documento di architettura;
+- aggiorna il mapping dei nodi se cambia la relazione con i task esistenti;
+- specifica eventuali dipendenze o fan‑out nel PR description;
+- indica l’impatto su scheduling e su eventuali ambienti (dev/prod).
+
+Riferimento: `docs/res_id-workflow.md`.
+
+---
+
 ## Pull Request Template
 
 ```markdown

--- a/docs/USER_STORIES_DETAILED.md
+++ b/docs/USER_STORIES_DETAILED.md
@@ -2340,6 +2340,42 @@ uv pip list | grep -E "llama|black|isort|flake8|pylint"
 
 ---
 
+## US-016: Orchestrazione Ingestion Scraper (DAG config)
+
+**Epic:** Document Ingestion  
+**Story Points:** 5  
+**Priority:** P1 - High  
+**Sprint:** 4  
+**Feature Branch:** `feature/US-016-ingestion-scraper`  
+**Status:** ✅ Done
+
+### User Story
+**Come** sistema  
+**Voglio** definire un workflow dichiarativo per le sorgenti scraper  
+**Per** aggiungere nuove fonti senza modificare l’orchestrazione
+
+### Acceptance Criteria
+- [x] Workflow definito in JSON/YAML con nodi e dipendenze
+- [x] Loader con validazione schema (Pydantic)
+- [x] Runner che converte il DAG in primitive Celery
+- [x] Schedule ogni 4h collegata al workflow
+- [x] Mapping nodi → task Celery esistenti
+
+### Technical Details
+- Workflow config: `config/workflows/res_id_workflow.yaml`
+- Schema/loader/runner: `src/core/workflows/`
+- Task orchestrazione: `src/services/workflows/tasks.py`
+- Integrazione Celery Beat: `src/services/embedding/celery_app.py`
+- Documentazione tecnica: `docs/res_id-workflow.md`
+
+### Definition of Done
+- [x] Loader e runner validati con test
+- [x] Fan-out supportato per res_id
+- [x] Task scraper allineate alle chiamate del servizio
+- [x] `make lint` e `make test` passano
+
+---
+
 ## Dipendenze tra User Stories
 
 ```mermaid
@@ -2363,6 +2399,7 @@ graph LR
 ```
 
 > **Note:** US-005 (Core) e US-013 (Celery) sono state separate per gestire volumi di 10.000+ CV con richieste multiple al giorno.
+> **Note:** US-016 introduce l’orchestrazione ibrida (Celery + DAG config); riferimento architetturale in `docs/res_id-workflow.md`.
 
 ---
 

--- a/docs/appendice_tecnica_indexing.md
+++ b/docs/appendice_tecnica_indexing.md
@@ -196,6 +196,10 @@ Esempio concettuale:
 
 ---
 
+## Collegamento con workflow `res_id`
+Per l’orchestrazione delle fonti e l’allineamento con il flusso di ingestione basato su `res_id`, fare riferimento a:
+- `docs/res_id-workflow.md`
+
 ## Principio finale di chiusura
 
 > **La qualità del sistema non dipende dal modello,

--- a/docs/res_id-workflow.md
+++ b/docs/res_id-workflow.md
@@ -1,0 +1,277 @@
+# Studio architettura workflow res_id (Celery + DAG config)
+
+## Obiettivo
+Definire un workflow modulare per l’ingestione di fonti dati legate a `res_id`, mantenendo **Celery come motore di esecuzione** ma introducendo un **DAG dichiarativo** configurato in JSON/YAML per consentire:
+- aggiunta di nuove fonti senza cambiare codice orchestration;
+- evoluzione graduale verso pipeline più complesse;
+- riuso di task e logica di retry/observability già esistente.
+
+---
+
+## Contesto
+Lo scraper fornisce **3 fonti principali**:
+1. Inside CV (`/inside/res-ids`, fan‑out su `/inside/cv/{res_id}`)
+2. Availability CSV (`/availability/csv`)
+3. Reskilling CSV (`/reskilling/csv`)
+
+Nel prossimo futuro potrebbero arrivare nuove fonti o step di arricchimento.  
+Serve quindi un layer di orchestration **espandibile** ma leggero.
+
+---
+
+## Decisione
+### ✅ Celery come executor
+- già presente nello stack
+- task già versionati e schedulati
+- compatibile con retry e logging
+
+### ✅ DAG dichiarativo
+- definito in file JSON/YAML (es. `config/workflows/res_id_workflow.yaml`)
+- caricato a runtime e trasformato in chain/group/chord Celery
+- consente di aggiungere nodi senza codice
+
+---
+
+## Concetto di DAG (config)
+Ogni nodo rappresenta un **task Celery** con:
+- `id` univoco
+- `task` (stringa importabile Celery)
+- `depends_on` (lista di nodi)
+- `params` (payload statico)
+- `fanout` opzionale (es: fan‑out su lista `res_ids`)
+- `retry_policy` override opzionale
+
+### Esempio (YAML)
+```/dev/null/res_id_workflow.yaml#L1-L40
+version: 1
+workflow_id: res_id_ingestion
+schedule: "0 */4 * * *"
+
+nodes:
+  - id: fetch_res_ids
+    task: src.services.scraper.tasks.scraper_inside_refresh_task
+
+  - id: inside_fanout
+    task: src.services.workflows.tasks.run_workflow_fanout_task
+    depends_on: [fetch_res_ids]
+    fanout:
+      source: redis:profilebot:scraper:inside:res_ids
+      task: src.services.scraper.tasks.scraper_inside_refresh_item_task
+      parameter_name: res_id
+
+  - id: export_availability
+    task: src.services.scraper.tasks.scraper_availability_csv_refresh_task
+
+  - id: export_reskilling
+    task: src.services.scraper.tasks.scraper_reskilling_csv_refresh_task
+```
+
+---
+
+## Orchestrazione dinamica
+### Caricamento
+1. Leggere YAML/JSON da path noto
+2. Validare schema (pydantic)
+3. Creare grafo in memoria
+4. Trasformare in chain/group
+
+### Strategia di esecuzione
+- nodi **senza dipendenze** → `group()`
+- nodi con dipendenze → `chain()` o `chord()`
+- eventuale fan‑out → generazione task dinamici
+
+---
+
+## Fan‑out su `res_id`
+Nel caso Inside CV:
+1. task `fetch_res_ids` recupera lista e la scrive in Redis
+2. DAG può avere un nodo “fan‑out” che legge la lista e genera task child:
+```/dev/null/fanout_example.yaml#L1-L20
+  - id: inside_fanout
+    task: src.services.workflows.tasks.run_workflow_fanout_task
+    depends_on: [fetch_res_ids]
+    fanout:
+      source: redis:profilebot:scraper:inside:res_ids
+      task: src.services.scraper.tasks.scraper_inside_refresh_item_task
+      parameter_name: res_id
+```
+
+Questa separazione permette:
+- riuso del `res_id` cache
+- aggiunta futura di nuove pipeline che usano la stessa lista
+
+---
+
+## Evoluzione futura
+Con nuove fonti si aggiunge un nodo e (eventualmente) un link di dipendenza, senza modificare l’orchestratore.
+
+### Esempio: “assessment” aggiuntivo
+```/dev/null/extra_source.yaml#L1-L10
+  - id: export_assessment
+    task: src.services.scraper.tasks.scraper_assessment_csv_refresh_task
+    depends_on: [export_availability]
+```
+
+---
+
+## Osservabilità
+- ogni task logga `workflow_id`, `node_id`, `status`
+- Flower già presente per visibilità runtime
+- possibile estensione con `task_annotations` per rate‑limit
+
+---
+
+## Schema Pydantic (proposta)
+Modello minimale per validare il DAG dichiarativo.
+
+```/dev/null/workflow_schema.py#L1-L60
+from __future__ import annotations
+
+from typing import Any
+from pydantic import BaseModel, Field
+
+class FanoutConfig(BaseModel):
+    source: str
+    task: str
+    parameter_name: str
+
+class RetryPolicy(BaseModel):
+    max_retries: int = Field(default=3, ge=0)
+    countdown: int = Field(default=60, ge=0)
+
+class WorkflowNode(BaseModel):
+    id: str
+    task: str
+    depends_on: list[str] = Field(default_factory=list)
+    params: dict[str, Any] = Field(default_factory=dict)
+    fanout: FanoutConfig | None = None
+    retry_policy: RetryPolicy | None = None
+
+class WorkflowDefinition(BaseModel):
+    version: int = 1
+    workflow_id: str
+    schedule: str | None = None
+    nodes: list[WorkflowNode]
+```
+
+---
+
+## Directory layout consigliato
+Struttura chiara per file di workflow e runner.
+
+```/dev/null/workflow_layout.txt#L1-L20
+config/
+  workflows/
+    res_id_workflow.yaml
+    res_id_workflow.dev.yaml
+
+src/
+  core/
+    workflows/
+      loader.py
+      runner.py
+      schemas.py
+```
+
+---
+
+## Loader (validazione) — esempio
+Esempio di caricamento e validazione del workflow da YAML/JSON con Pydantic.
+
+```/dev/null/workflow_loader_example.py#L1-L40
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from src.core.workflows.schemas import WorkflowDefinition
+
+def load_workflow(path: Path) -> WorkflowDefinition:
+    raw = path.read_text(encoding="utf-8")
+    if path.suffix in {".yaml", ".yml"}:
+        payload = yaml.safe_load(raw)
+    else:
+        payload = json.loads(raw)
+    return WorkflowDefinition.model_validate(payload)
+```
+
+---
+
+## WorkflowRunner — pseudocodice
+Conversione del DAG in primitive Celery (`group`, `chain`, `chord`).
+
+```/dev/null/workflow_runner_pseudocode.py#L1-L60
+def run_workflow(definition):
+    nodes = index_by_id(definition.nodes)
+    graph = build_dependency_graph(nodes)
+
+    def build_task(node):
+        signature = celery.signature(node.task, kwargs=node.params)
+        if node.retry_policy:
+            signature.set(
+                retries=node.retry_policy.max_retries,
+                countdown=node.retry_policy.countdown,
+            )
+        return signature
+
+    roots = [n for n in nodes if not n.depends_on]
+    if not roots:
+        raise ValueError("Workflow has no root nodes")
+
+    parallel_roots = group(build_task(n) for n in roots)
+
+    return parallel_roots  # or chain/chord based on dependencies
+```
+
+---
+
+## Mapping nodi DAG ↔ task Celery esistenti
+Tabella di riferimento per collegare i nodi del DAG ai task già disponibili.
+
+| Nodo DAG (id) | Task Celery | Note |
+| --- | --- | --- |
+| fetch_res_ids | src.services.scraper.tasks.scraper_inside_refresh_task | Recupera res_id, fan‑out interno, cache su Redis |
+| inside_fanout | src.services.workflows.tasks.run_workflow_fanout_task | Esegue fan‑out su res_id cached e lancia refresh per item |
+| export_availability | src.services.scraper.tasks.scraper_availability_csv_refresh_task | Export CSV availability |
+| export_reskilling | src.services.scraper.tasks.scraper_reskilling_csv_refresh_task | Export CSV reskilling |
+
+---
+
+## Impatti su altri documenti in docs
+Se introduciamo il DAG dichiarativo, alcuni documenti potrebbero richiedere aggiornamento per coerenza:
+
+- `docs/USER_STORIES_DETAILED.md`: se la US‑016 deve includere il DAG dichiarativo o la logica di orchestrazione.
+- `docs/BACKLOG.md`: per inserire attività su loader/runner o gestione workflow config.
+- `docs/CONTRIBUTING.md`: se servono istruzioni su come aggiungere nuovi nodi al DAG.
+- `docs/analisi_preliminare.md`: per riflettere l’evoluzione dell’architettura di ingestione.
+- `docs/appendice_tecnica_indexing.md`: se il processo di ingestione influisce sul flusso di indicizzazione.
+- `docs/technical_debpt.md`: se l’orchestrazione custom introduce debito tecnico o decisioni da tracciare.
+
+---
+
+## Trade‑off
+### Pro
+- basso overhead
+- incrementale
+- compatibile con struttura attuale
+
+### Contro
+- orchestrazione custom
+- meno features native rispetto a Prefect/Airflow
+
+---
+
+## Raccomandazione operativa
+1. Implementare un loader `WorkflowDefinition` (Pydantic)
+2. Introdurre un `WorkflowRunner` che converte il DAG in Celery primitives
+3. Introdurre un file `res_id_workflow.yaml`
+4. Collegare il schedule Celery alla definizione del workflow
+
+---
+
+## Output attesi
+- Pipeline dichiarativa per `res_id`
+- Aggiunta fonti future senza refactor
+- Esecuzione stabile ogni 4h con Celery

--- a/docs/scraper-service/scraper-service-openapi.yaml
+++ b/docs/scraper-service/scraper-service-openapi.yaml
@@ -1,0 +1,338 @@
+openapi: 3.0.3
+info:
+  title: Scraper Service
+  version: 0.1.0
+  description: |
+    Raw-only scraping service for Inside CVs, SharePoint Availability, and Reskilling lists.
+    The API returns raw files and rows without normalization.
+servers:
+  - url: http://localhost:8001
+tags:
+  - name: health
+    description: Service health check.
+  - name: inside
+    description: Inside CV scraping endpoints.
+  - name: availability
+    description: SharePoint Availability list endpoints.
+  - name: reskilling
+    description: Reskilling list endpoints.
+
+paths:
+  /health:
+    get:
+      tags: [health]
+      summary: Health check
+      description: Returns service status.
+      operationId: getHealth
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              examples:
+                ok:
+                  value: { status: ok }
+
+  /inside/res-ids:
+    get:
+      tags: [inside]
+      summary: List Inside res_id values
+      description: Returns the list of available res_id values from Inside.
+      operationId: listInsideResIds
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResIdsResponse"
+              examples:
+                example:
+                  value:
+                    res_ids: ["210513", "210514"]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /inside/cv/{res_id}:
+    get:
+      tags: [inside]
+      summary: Download CV by res_id
+      description: Returns the CV document for the given res_id.
+      operationId: getInsideCv
+      parameters:
+        - $ref: "#/components/parameters/ResIdPath"
+      responses:
+        "200":
+          description: CV file
+          content:
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags: [inside]
+      summary: Download CV and return path
+      description: Downloads the CV and returns the local path on disk.
+      operationId: downloadInsideCv
+      parameters:
+        - $ref: "#/components/parameters/ResIdPath"
+      responses:
+        "200":
+          description: CV saved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadResponse"
+              examples:
+                example:
+                  value:
+                    path: /data/output/inside/curriculum_210513.docx
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /availability/csv:
+    get:
+      tags: [availability]
+      summary: Download latest Availability CSV
+      description: Returns the most recent Availability CSV file.
+      operationId: getAvailabilityCsv
+      responses:
+        "200":
+          description: CSV file
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags: [availability]
+      summary: Export Availability CSV
+      description: Scrapes the Availability list and returns the saved CSV path and row count.
+      operationId: exportAvailabilityCsv
+      responses:
+        "200":
+          description: CSV exported
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CsvExportResponse"
+              examples:
+                example:
+                  value:
+                    path: /data/output/availability/availability_list.csv
+                    rows: 1234
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /availability/csv/{res_id}:
+    get:
+      tags: [availability]
+      summary: Get Availability row by res_id
+      description: Returns the CSV row for the given ResID.
+      operationId: getAvailabilityRow
+      parameters:
+        - $ref: "#/components/parameters/ResIdPath"
+      responses:
+        "200":
+          description: Row found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RowResponse"
+              examples:
+                example:
+                  value:
+                    res_id: "210513"
+                    row:
+                      ResID: "210513"
+                      Risorsa: "Donnemma, Debora"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /reskilling/csv:
+    get:
+      tags: [reskilling]
+      summary: Download latest Reskilling CSV
+      description: Returns the most recent Reskilling CSV file.
+      operationId: getReskillingCsv
+      responses:
+        "200":
+          description: CSV file
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags: [reskilling]
+      summary: Export Reskilling CSV
+      description: Scrapes the Reskilling list and returns the saved CSV path and row count.
+      operationId: exportReskillingCsv
+      responses:
+        "200":
+          description: CSV exported
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CsvExportResponse"
+              examples:
+                example:
+                  value:
+                    path: /data/output/reskilling/reskilling_list.csv
+                    rows: 456
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /reskilling/csv/{res_id}:
+    get:
+      tags: [reskilling]
+      summary: Get Reskilling row by res_id
+      description: Returns the CSV row for the given Consultant ID.
+      operationId: getReskillingRow
+      parameters:
+        - $ref: "#/components/parameters/ResIdPath"
+      responses:
+        "200":
+          description: Row found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RowResponse"
+              examples:
+                example:
+                  value:
+                    res_id: "210513"
+                    row:
+                      "Risorsa:Consultant ID": "210513"
+                      "Risorsa": "Donnemma, Debora"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  parameters:
+    ResIdPath:
+      name: res_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Resource identifier (ResID / Consultant ID).
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ServiceUnavailable:
+      description: Service unavailable
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    HealthResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        status:
+          type: string
+      required: [status]
+
+    ResIdsResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        res_ids:
+          type: array
+          items:
+            type: string
+      required: [res_ids]
+
+    DownloadResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+      required: [path]
+
+    CsvExportResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+        rows:
+          type: integer
+          minimum: 0
+      required: [path, rows]
+
+    RowResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        res_id:
+          type: string
+        row:
+          type: object
+          additionalProperties: true
+      required: [res_id, row]
+
+    ErrorResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        detail:
+          type: string
+      required: [detail]

--- a/docs/technical_debpt.md
+++ b/docs/technical_debpt.md
@@ -170,7 +170,9 @@
 
 **Titolo:** Introdurre un orchestratore per pipeline con consumer esterni e monitoring unificato  
 **Motivazione:** crescita delle fonti e formati richiede coordinamento end‑to‑end e visibilità unica  
-**Obiettivo:** centralizzare la gestione delle pipeline per source type, includendo consumer per producer esterni **sotto un’unica UI**
+**Obiettivo:** centralizzare la gestione delle pipeline per source type, includendo consumer per producer esterni **sotto un’unica UI**  
+
+**Nota interim (US-016):** adozione di un DAG dichiarativo (JSON/YAML) con Celery come executor, in attesa di un orchestratore completo. Il DAG definisce nodi, dipendenze e fan‑out; mapping e policy sono documentati in `docs/res_id-workflow.md`.
 
 ### Architettura da usare/modificare
 - **Orchestratore unico** (Prefect/Dagster) come livello di controllo dei flow, **UI condivisa**

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
         default=300,
         validation_alias="CELERY_TASK_TIME_LIMIT",
     )
+    scraper_base_url: str = Field(
+        default="",
+        validation_alias="SCRAPER_BASE_URL",
+    )
+    scraper_workflow_path: str = Field(
+        default="config/workflows/res_id_workflow.yaml",
+        validation_alias="SCRAPER_WORKFLOW_PATH",
+    )
 
 
 @lru_cache(maxsize=1)

--- a/src/core/workflows/__init__.py
+++ b/src/core/workflows/__init__.py
@@ -1,0 +1,19 @@
+"""Workflow orchestration exports."""
+
+from src.core.workflows.loader import load_workflow
+from src.core.workflows.runner import WorkflowRunner
+from src.core.workflows.schemas import (
+    FanoutConfig,
+    RetryPolicy,
+    WorkflowDefinition,
+    WorkflowNode,
+)
+
+__all__ = [
+    "FanoutConfig",
+    "RetryPolicy",
+    "WorkflowDefinition",
+    "WorkflowNode",
+    "WorkflowRunner",
+    "load_workflow",
+]

--- a/src/core/workflows/loader.py
+++ b/src/core/workflows/loader.py
@@ -1,0 +1,44 @@
+"""Workflow definition loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from pydantic import ValidationError
+
+from src.core.workflows.schemas import WorkflowDefinition
+
+
+def load_workflow(path: Path) -> WorkflowDefinition:
+    """Load and validate a workflow definition from YAML/JSON."""
+    payload = _load_payload(path)
+    try:
+        return cast(WorkflowDefinition, WorkflowDefinition.model_validate(payload))
+    except ValidationError as exc:
+        raise ValueError(f"Invalid workflow definition in {path}") from exc
+
+
+def _load_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Workflow file not found: {path}")
+    raw = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        payload = yaml.safe_load(raw)
+        if payload is None:
+            return {}
+        if isinstance(payload, dict):
+            return payload
+        raise ValueError("Workflow YAML payload must be a mapping")
+    if suffix == ".json":
+        payload = json.loads(raw)
+        if isinstance(payload, dict):
+            return payload
+        raise ValueError("Workflow JSON payload must be a mapping")
+    raise ValueError(f"Unsupported workflow file type: {suffix}")
+
+
+__all__ = ["load_workflow"]

--- a/src/core/workflows/runner.py
+++ b/src/core/workflows/runner.py
@@ -1,0 +1,88 @@
+"""Workflow runner that converts DAG definitions to Celery canvas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from celery import Celery, chain, group, signature
+from celery.canvas import Signature
+from celery.result import AsyncResult
+
+from src.core.workflows.schemas import WorkflowDefinition, WorkflowNode
+
+
+@dataclass(frozen=True)
+class WorkflowRunner:
+    """Runner for workflow definitions."""
+
+    app: Celery | None = None
+
+    def build_canvas(self, definition: WorkflowDefinition) -> Signature:
+        """Build a Celery canvas from a workflow definition."""
+        return _build_canvas(definition, app=self.app)
+
+    def run(self, definition: WorkflowDefinition) -> AsyncResult:
+        """Build and trigger the workflow canvas."""
+        canvas = self.build_canvas(definition)
+        return canvas.apply_async()
+
+
+def _build_canvas(definition: WorkflowDefinition, *, app: Celery | None) -> Signature:
+    levels = _topological_levels(definition)
+    stages: list[Signature] = []
+    for level in levels:
+        signatures = [_signature_for(node, app) for node in level]
+        if len(signatures) == 1:
+            stages.append(signatures[0])
+        else:
+            stages.append(group(signatures))
+    if len(stages) == 1:
+        return stages[0]
+    return chain(*stages)
+
+
+def _topological_levels(definition: WorkflowDefinition) -> list[list[WorkflowNode]]:
+    nodes_by_id = {node.id: node for node in definition.nodes}
+    dependents: dict[str, set[str]] = {node_id: set() for node_id in nodes_by_id}
+    in_degree = {node.id: len(node.depends_on) for node in definition.nodes}
+    for node in definition.nodes:
+        for dependency in node.depends_on:
+            dependents[dependency].add(node.id)
+    ready = sorted(node_id for node_id, count in in_degree.items() if count == 0)
+    levels: list[list[WorkflowNode]] = []
+    processed = 0
+    while ready:
+        current_ids = ready
+        levels.append([nodes_by_id[node_id] for node_id in current_ids])
+        processed += len(current_ids)
+        next_ready: list[str] = []
+        for node_id in current_ids:
+            for dependent in dependents[node_id]:
+                in_degree[dependent] -= 1
+                if in_degree[dependent] == 0:
+                    next_ready.append(dependent)
+        ready = sorted(next_ready)
+    if processed != len(nodes_by_id):
+        raise ValueError("Workflow contains cyclic dependencies")
+    return levels
+
+
+def _signature_for(node: WorkflowNode, app: Celery | None) -> Signature:
+    kwargs = dict(node.params)
+    if node.fanout is not None:
+        kwargs["fanout_source"] = node.fanout.source
+        kwargs["fanout_task"] = node.fanout.task
+        kwargs["fanout_parameter_name"] = node.fanout.parameter_name
+    if app:
+        sig = app.signature(node.task, kwargs=kwargs)
+    else:
+        sig = signature(node.task, kwargs=kwargs)
+    if node.retry_policy:
+        sig = sig.set(
+            retries=node.retry_policy.max_retries,
+            countdown=node.retry_policy.countdown,
+        )
+    return sig
+
+
+__all__ = ["WorkflowRunner"]

--- a/src/core/workflows/schemas.py
+++ b/src/core/workflows/schemas.py
@@ -1,0 +1,68 @@
+"""Workflow schema models for DAG configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class FanoutConfig(BaseModel):
+    """Configuration for fan-out execution."""
+
+    source: str
+    task: str
+    parameter_name: str = "res_id"
+
+
+class RetryPolicy(BaseModel):
+    """Retry policy overrides for workflow nodes."""
+
+    max_retries: int = Field(default=3, ge=0)
+    countdown: int = Field(default=60, ge=0)
+
+
+class WorkflowNode(BaseModel):
+    """Single node definition for a workflow DAG."""
+
+    id: str
+    task: str
+    depends_on: list[str] = Field(default_factory=list)
+    params: dict[str, Any] = Field(default_factory=dict)
+    fanout: FanoutConfig | None = None
+    retry_policy: RetryPolicy | None = None
+
+
+class WorkflowDefinition(BaseModel):
+    """Top-level workflow definition."""
+
+    version: int = 1
+    workflow_id: str
+    schedule: str | None = None
+    nodes: list[WorkflowNode]
+
+    @model_validator(mode="after")
+    def _validate_nodes(self) -> WorkflowDefinition:
+        if not self.nodes:
+            raise ValueError("Workflow nodes must not be empty")
+        node_ids = [node.id for node in self.nodes]
+        if len(node_ids) != len(set(node_ids)):
+            raise ValueError("Workflow node IDs must be unique")
+        node_id_set = set(node_ids)
+        missing = {
+            dependency
+            for node in self.nodes
+            for dependency in node.depends_on
+            if dependency not in node_id_set
+        }
+        if missing:
+            raise ValueError(f"Unknown workflow dependencies: {sorted(missing)}")
+        return self
+
+
+__all__ = [
+    "FanoutConfig",
+    "RetryPolicy",
+    "WorkflowDefinition",
+    "WorkflowNode",
+]

--- a/src/services/embedding/celery_app.py
+++ b/src/services/embedding/celery_app.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from celery import Celery
 from celery.schedules import crontab
 
 from src.core.config import get_settings
+from src.core.workflows.loader import load_workflow
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -19,18 +21,38 @@ celery_app = Celery(
     include=[
         "src.services.embedding.tasks",
         "src.services.availability.tasks",
+        "src.services.scraper.tasks",
+        "src.services.workflows.tasks",
     ],
 )
 
 CRON_FIELDS = 5
+DEFAULT_AVAILABILITY_SCHEDULE = crontab(minute=0)
+DEFAULT_SCRAPER_SCHEDULE = crontab(minute=0, hour="*/4")
+SCRAPER_WORKFLOW_TASK = "src.services.workflows.tasks.run_scraper_workflow_task"
 
 
-def _parse_cron_schedule(value: str):
+def _parse_cron_schedule(value: str, *, default: crontab) -> crontab:
     parts = value.split()
     if len(parts) != CRON_FIELDS:
-        logger.warning("Invalid availability cron '%s', defaulting to hourly", value)
-        return crontab(minute=0)
+        logger.warning("Invalid cron %s, defaulting to %s", value, default)
+        return default
     return crontab(*parts)
+
+
+def _resolve_scraper_schedule() -> crontab:
+    path = Path(settings.scraper_workflow_path)
+    try:
+        definition = load_workflow(path)
+    except FileNotFoundError:
+        logger.warning("Scraper workflow file not found: %s", path)
+        return DEFAULT_SCRAPER_SCHEDULE
+    except ValueError as exc:
+        logger.warning("Invalid scraper workflow file %s: %s", path, exc)
+        return DEFAULT_SCRAPER_SCHEDULE
+    if not definition.schedule:
+        return DEFAULT_SCRAPER_SCHEDULE
+    return _parse_cron_schedule(definition.schedule, default=DEFAULT_SCRAPER_SCHEDULE)
 
 
 celery_app.conf.update(
@@ -47,8 +69,15 @@ celery_app.conf.update(
     beat_schedule={
         "availability-refresh": {
             "task": "src.services.availability.tasks.availability_refresh_task",
-            "schedule": _parse_cron_schedule(settings.availability_refresh_schedule),
-        }
+            "schedule": _parse_cron_schedule(
+                settings.availability_refresh_schedule,
+                default=DEFAULT_AVAILABILITY_SCHEDULE,
+            ),
+        },
+        "scraper-workflow": {
+            "task": SCRAPER_WORKFLOW_TASK,
+            "schedule": _resolve_scraper_schedule(),
+        },
     },
 )
 

--- a/src/services/scraper/__init__.py
+++ b/src/services/scraper/__init__.py
@@ -1,0 +1,11 @@
+"""Scraper service exports."""
+
+from src.services.scraper.cache import DEFAULT_RES_IDS_KEY, ScraperResIdCache
+from src.services.scraper.client import ScraperClient, ScraperClientConfig
+
+__all__ = [
+    "DEFAULT_RES_IDS_KEY",
+    "ScraperClient",
+    "ScraperClientConfig",
+    "ScraperResIdCache",
+]

--- a/src/services/scraper/cache.py
+++ b/src/services/scraper/cache.py
@@ -1,0 +1,61 @@
+"""Redis cache for scraper res IDs."""
+
+from __future__ import annotations
+
+import json
+
+import redis
+
+from src.core.config import get_settings
+
+DEFAULT_RES_IDS_KEY = "profilebot:scraper:inside:res_ids"
+
+
+class ScraperResIdCache:
+    """Redis-backed cache for scraper res IDs."""
+
+    def __init__(
+        self,
+        client: redis.Redis | None = None,
+        *,
+        key: str = DEFAULT_RES_IDS_KEY,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._client: redis.Redis = client or redis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+        )
+        self._key = key
+        self._ttl_seconds = ttl_seconds
+
+    def get_res_ids(self) -> list[int]:
+        """Return cached res IDs, or an empty list when missing."""
+        raw = self._client.get(self._key)
+        if not raw:
+            return []
+        payload = json.loads(raw)
+        if not isinstance(payload, list):
+            raise ValueError("Invalid res ID payload in cache")
+        return [int(value) for value in payload]
+
+    def set_res_ids(self, res_ids: list[int]) -> None:
+        """Store res IDs in cache, optionally with TTL."""
+        payload = json.dumps([int(value) for value in res_ids])
+        if self._ttl_seconds:
+            self._client.setex(self._key, self._ttl_seconds, payload)
+        else:
+            self._client.set(self._key, payload)
+
+    def ping(self) -> bool:
+        """Check Redis connectivity."""
+        try:
+            return bool(self._client.ping())
+        except redis.RedisError:
+            return False
+
+
+__all__ = [
+    "DEFAULT_RES_IDS_KEY",
+    "ScraperResIdCache",
+]

--- a/src/services/scraper/client.py
+++ b/src/services/scraper/client.py
@@ -1,0 +1,110 @@
+"""HTTP client for the legacy scraper service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from src.core.config import get_settings
+
+
+@dataclass(frozen=True)
+class ScraperClientConfig:
+    """Configuration for the scraper client."""
+
+    base_url: str
+    timeout_seconds: float = 30.0
+
+
+class ScraperClient:
+    """Synchronous client for the legacy scraper service."""
+
+    def __init__(
+        self,
+        *,
+        config: ScraperClientConfig | None = None,
+        client: httpx.Client | None = None,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        settings = get_settings()
+        resolved_config = config or ScraperClientConfig(base_url=settings.scraper_base_url)
+        base_url = resolved_config.base_url.strip()
+        if not base_url:
+            raise ValueError("Scraper base URL is required")
+        self._config = ScraperClientConfig(
+            base_url=base_url,
+            timeout_seconds=resolved_config.timeout_seconds,
+        )
+        self._client = client or httpx.Client(
+            base_url=self._config.base_url,
+            timeout=self._config.timeout_seconds,
+            transport=transport,
+        )
+
+    @property
+    def base_url(self) -> str:
+        """Return the configured base URL."""
+        return self._config.base_url
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    def __enter__(self) -> ScraperClient:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def get(self, path: str) -> Any:
+        """Perform a GET request and return JSON response."""
+        return self._request("GET", path)
+
+    def post(self, path: str, *, json: dict[str, Any] | None = None) -> Any:
+        """Perform a POST request and return JSON response."""
+        return self._request("POST", path, json=json)
+
+    def fetch_inside_res_ids(self) -> list[int]:
+        """Return list of res IDs from the Inside endpoint."""
+        payload = self.get("/inside/res-ids")
+        if isinstance(payload, dict):
+            payload = payload.get("res_ids")
+        if not isinstance(payload, list):
+            raise ValueError("Invalid response for /inside/res-ids")
+        res_ids: list[int] = []
+        for value in payload:
+            try:
+                res_id = int(str(value).strip())
+            except (TypeError, ValueError):
+                continue
+            if res_id:
+                res_ids.append(res_id)
+        return res_ids
+
+    def refresh_inside_cv(self, res_id: int) -> None:
+        """Trigger refresh for a single Inside CV."""
+        self.post(f"/inside/cv/{res_id}")
+
+    def export_availability_csv(self) -> None:
+        """Trigger the availability CSV export."""
+        self.post("/availability/csv")
+
+    def export_reskilling_csv(self) -> None:
+        """Trigger the reskilling CSV export."""
+        self.post("/reskilling/csv")
+
+    def _request(self, method: str, path: str, *, json: dict[str, Any] | None = None) -> Any:
+        response = self._client.request(method, path, json=json)
+        response.raise_for_status()
+
+        if not response.content:
+            return None
+        return response.json()
+
+
+__all__ = [
+    "ScraperClient",
+    "ScraperClientConfig",
+]

--- a/src/services/scraper/tasks.py
+++ b/src/services/scraper/tasks.py
@@ -1,0 +1,129 @@
+"""Celery tasks for scraper ingestion refresh jobs."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import redis
+
+from src.core.config import get_settings
+from src.services.embedding.celery_app import celery_app
+from src.services.scraper.cache import DEFAULT_RES_IDS_KEY, ScraperResIdCache
+from src.services.scraper.client import ScraperClient
+
+logger = logging.getLogger(__name__)
+
+RETRY_COUNTDOWN = 60
+
+
+def _ensure_scraper_base_url() -> str | None:
+    settings = get_settings()
+    base_url = settings.scraper_base_url.strip()
+    if not base_url:
+        logger.warning("SCRAPER_BASE_URL not configured")
+        return None
+    return base_url
+
+
+@celery_app.task(bind=True, max_retries=3)
+def scraper_inside_refresh_task(self) -> dict[str, Any]:
+    """Refresh Inside CVs and store res IDs in Redis."""
+    cache = ScraperResIdCache()
+
+    if not _ensure_scraper_base_url():
+        return {"status": "skipped", "reason": "SCRAPER_BASE_URL not configured"}
+
+    logger.info("Starting Inside CV refresh")
+    try:
+        with ScraperClient() as client:
+            res_ids = client.fetch_inside_res_ids()
+            cache.set_res_ids(res_ids)
+            failed_res_ids: list[int] = []
+            for res_id in res_ids:
+                try:
+                    client.refresh_inside_cv(res_id)
+                except httpx.RequestError as exc:
+                    logger.warning("Inside CV refresh failed for res_id %s: %s", res_id, exc)
+                    raise self.retry(exc=exc, countdown=RETRY_COUNTDOWN) from exc
+                except httpx.HTTPStatusError as exc:
+                    logger.warning("Inside CV refresh failed for res_id %s: %s", res_id, exc)
+                    failed_res_ids.append(res_id)
+            status = "partial_success" if failed_res_ids else "success"
+            logger.info("Inside CV refresh completed with %d res_ids", len(res_ids))
+            return {
+                "status": status,
+                "res_ids_count": len(res_ids),
+                "failed_res_ids": failed_res_ids,
+                "cache_key": DEFAULT_RES_IDS_KEY,
+            }
+    except httpx.RequestError as exc:
+        logger.warning("Scraper Inside refresh failed: %s", exc)
+        raise self.retry(exc=exc, countdown=RETRY_COUNTDOWN) from exc
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Scraper Inside refresh failed: %s", exc)
+        return {"status": "failed", "reason": str(exc)}
+    except redis.RedisError as exc:
+        logger.warning("Redis error during Inside refresh: %s", exc)
+        raise self.retry(exc=exc, countdown=RETRY_COUNTDOWN) from exc
+    except (TypeError, ValueError) as exc:
+        logger.warning("Scraper Inside configuration/payload error: %s", exc)
+        return {"status": "failed", "reason": str(exc)}
+
+
+@celery_app.task(bind=True, max_retries=3)
+def scraper_inside_refresh_item_task(self, *, res_id: int) -> dict[str, Any]:
+    """Refresh a single Inside CV by res_id."""
+    if not _ensure_scraper_base_url():
+        return {"status": "skipped", "reason": "SCRAPER_BASE_URL not configured"}
+
+    try:
+        with ScraperClient() as client:
+            client.refresh_inside_cv(res_id)
+        return {"status": "success", "res_id": res_id}
+    except httpx.RequestError as exc:
+        logger.warning("Inside CV refresh failed for res_id %s: %s", res_id, exc)
+        raise self.retry(exc=exc, countdown=RETRY_COUNTDOWN) from exc
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Inside CV refresh failed for res_id %s: %s", res_id, exc)
+        return {"status": "failed", "reason": str(exc), "res_id": res_id}
+    except (TypeError, ValueError) as exc:
+        logger.warning("Inside CV refresh failed for res_id %s: %s", res_id, exc)
+        return {"status": "failed", "reason": str(exc), "res_id": res_id}
+
+
+@celery_app.task(bind=True, max_retries=3)
+def scraper_availability_csv_refresh_task(self) -> dict[str, Any]:
+    """Trigger the availability CSV export."""
+    if not _ensure_scraper_base_url():
+        return {"status": "skipped", "reason": "SCRAPER_BASE_URL not configured"}
+
+    try:
+        with ScraperClient() as client:
+            client.export_availability_csv()
+        return {"status": "success"}
+    except httpx.RequestError as exc:
+        logger.warning("Scraper availability export failed: %s", exc)
+        raise self.retry(exc=exc, countdown=RETRY_COUNTDOWN) from exc
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Scraper availability export failed: %s", exc)
+        return {"status": "failed", "reason": str(exc)}
+
+
+@celery_app.task(bind=True, max_retries=3)
+def scraper_reskilling_csv_refresh_task(self) -> dict[str, Any]:
+    """Trigger the reskilling CSV export."""
+    if not _ensure_scraper_base_url():
+        return {"status": "skipped", "reason": "SCRAPER_BASE_URL not configured"}
+
+    try:
+        with ScraperClient() as client:
+            client.export_reskilling_csv()
+        return {"status": "success"}
+    except httpx.RequestError as exc:
+        logger.warning("Scraper reskilling export failed: %s", exc)
+        raise self.retry(exc=exc, countdown=RETRY_COUNTDOWN) from exc
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Scraper reskilling export failed: %s", exc)
+        return {"status": "failed", "reason": str(exc)}

--- a/src/services/workflows/__init__.py
+++ b/src/services/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow service exports."""
+
+from src.services.workflows.tasks import run_scraper_workflow_task, run_workflow_fanout_task
+
+__all__ = ["run_scraper_workflow_task", "run_workflow_fanout_task"]

--- a/src/services/workflows/tasks.py
+++ b/src/services/workflows/tasks.py
@@ -1,0 +1,80 @@
+"""Celery tasks for workflow orchestration."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from celery import group, signature
+
+from src.core.config import get_settings
+from src.core.workflows.loader import load_workflow
+from src.core.workflows.runner import WorkflowRunner
+from src.services.embedding.celery_app import celery_app
+from src.services.scraper.cache import ScraperResIdCache
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task
+def run_scraper_workflow_task(*, workflow_path: str | None = None) -> dict[str, Any]:
+    """Trigger the scraper ingestion workflow."""
+    settings = get_settings()
+    resolved_path = Path(workflow_path or settings.scraper_workflow_path)
+    definition = load_workflow(resolved_path)
+    runner = WorkflowRunner(app=celery_app)
+    result = runner.run(definition)
+    logger.info(
+        "Triggered workflow %s with root task %s",
+        definition.workflow_id,
+        result.id,
+    )
+    return {
+        "status": "triggered",
+        "workflow_id": definition.workflow_id,
+        "root_task_id": result.id,
+        "node_count": len(definition.nodes),
+    }
+
+
+@celery_app.task
+def run_workflow_fanout_task(
+    *,
+    fanout_source: str,
+    fanout_task: str,
+    fanout_parameter_name: str = "res_id",
+) -> dict[str, Any]:
+    """Trigger a fan-out based on a cached res_id list."""
+    res_ids = _load_fanout_res_ids(fanout_source)
+    if not res_ids:
+        logger.info("Fanout skipped, no res_ids found for %s", fanout_source)
+        return {"status": "skipped", "res_ids_count": 0}
+
+    signatures = [
+        signature(fanout_task, kwargs={fanout_parameter_name: res_id}) for res_id in res_ids
+    ]
+    result = group(signatures).apply_async()
+    child_ids = [child.id for child in (result.children or [])]
+
+    logger.info(
+        "Triggered fanout for %d res_ids with group %s",
+        len(res_ids),
+        result.id,
+    )
+    return {
+        "status": "triggered",
+        "res_ids_count": len(res_ids),
+        "group_id": result.id,
+        "child_task_ids": child_ids,
+    }
+
+
+def _load_fanout_res_ids(fanout_source: str) -> list[int]:
+    if not fanout_source.startswith("redis:"):
+        raise ValueError(f"Unsupported fanout source: {fanout_source}")
+    key = fanout_source.replace("redis:", "", 1)
+    if not key:
+        raise ValueError("Fanout source key is required")
+    cache = ScraperResIdCache(key=key)
+    return cache.get_res_ids()

--- a/tests/test_scraper_cache.py
+++ b/tests/test_scraper_cache.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+import redis
+
+from src.services.scraper.cache import DEFAULT_RES_IDS_KEY, ScraperResIdCache
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+        self._expirations: dict[str, int] = {}
+
+    def get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        self._store[key] = value
+        self._expirations[key] = ttl
+
+    def ping(self) -> bool:
+        return True
+
+
+def test_cache_set_and_get_roundtrip() -> None:
+    client = FakeRedis()
+    cache = ScraperResIdCache(client=cast(redis.Redis, client))
+
+    cache.set_res_ids([101, 202, 303])
+    stored = cache.get_res_ids()
+
+    assert stored == [101, 202, 303]
+
+
+def test_cache_get_missing_returns_empty_list() -> None:
+    cache = ScraperResIdCache(client=cast(redis.Redis, FakeRedis()))
+
+    assert cache.get_res_ids() == []
+
+
+def test_cache_set_res_ids_normalizes_values() -> None:
+    client = FakeRedis()
+    cache = ScraperResIdCache(client=cast(redis.Redis, client))
+
+    cache.set_res_ids([101, 202, 303])
+    raw = client.get(DEFAULT_RES_IDS_KEY)
+
+    assert raw is not None
+    assert json.loads(raw) == [101, 202, 303]
+
+
+def test_cache_get_invalid_payload_raises_value_error() -> None:
+    client = FakeRedis()
+    client.set(DEFAULT_RES_IDS_KEY, json.dumps({"bad": "payload"}))
+    cache = ScraperResIdCache(client=cast(redis.Redis, client))
+
+    with pytest.raises(ValueError, match="Invalid res ID payload"):
+        cache.get_res_ids()
+
+
+def test_cache_set_res_ids_with_ttl_uses_setex() -> None:
+    client = FakeRedis()
+    cache = ScraperResIdCache(client=cast(redis.Redis, client), ttl_seconds=1800)
+
+    cache.set_res_ids([101, 202])
+
+    assert client._expirations[DEFAULT_RES_IDS_KEY] == 1800
+
+
+def test_cache_ping_returns_true() -> None:
+    cache = ScraperResIdCache(client=cast(redis.Redis, FakeRedis()))
+
+    assert cache.ping() is True

--- a/tests/test_scraper_client.py
+++ b/tests/test_scraper_client.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from src.services.scraper.client import ScraperClient, ScraperClientConfig
+
+
+def test_fetch_inside_res_ids__valid_payload__returns_normalized_ids() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/inside/res-ids"
+        return httpx.Response(200, json=["1", 2, " ", None, "003"])
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with client:
+        result = client.fetch_inside_res_ids()
+
+    assert result == [1, 2, 3]
+
+
+def test_fetch_inside_res_ids__object_payload__returns_normalized_ids() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/inside/res-ids"
+        return httpx.Response(200, json={"res_ids": ["10", "020", None, ""]})
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with client:
+        result = client.fetch_inside_res_ids()
+
+    assert result == [10, 20]
+
+
+def test_fetch_inside_res_ids__invalid_payload__raises_value_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"res_ids": "invalid"})
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError, match="Invalid response for /inside/res-ids"):
+        with client:
+            client.fetch_inside_res_ids()
+
+
+def test_refresh_inside_cv__posts_to_expected_path() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with client:
+        client.refresh_inside_cv(123)
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/inside/cv/123"
+
+
+def test_export_availability_csv__posts_to_expected_path() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with client:
+        client.export_availability_csv()
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/availability/csv"
+
+
+def test_export_reskilling_csv__posts_to_expected_path() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with client:
+        client.export_reskilling_csv()
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/reskilling/csv"
+
+
+def test_request_error__propagates_httpx_request_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with pytest.raises(httpx.RequestError):
+        with client:
+            client.fetch_inside_res_ids()
+
+
+def test_http_status_error__propagates_httpx_status_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        with client:
+            client.export_availability_csv()

--- a/tests/test_scraper_tasks.py
+++ b/tests/test_scraper_tasks.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+from src.services.scraper import tasks as scraper_tasks
+from src.services.scraper.client import ScraperClient, ScraperClientConfig
+
+
+class RetryCalled(RuntimeError):
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(str(exc))
+        self.exc = exc
+
+
+class DummyTask:
+    def retry(self, *, exc: Exception, countdown: int) -> None:
+        raise RetryCalled(exc)
+
+
+@dataclass
+class FakeCache:
+    stored: list[int] | None = None
+
+    def set_res_ids(self, res_ids: list[int]) -> None:
+        self.stored = res_ids
+
+
+def _set_base_url(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(
+        scraper_tasks,
+        "_ensure_scraper_base_url",
+        lambda: value,
+        raising=True,
+    )
+
+
+def _mock_client(transport: httpx.MockTransport) -> ScraperClient:
+    return ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+
+def test_scraper_inside_refresh_task__stores_res_ids_and_returns_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_base_url(monkeypatch, "https://scraper")
+
+    fake_cache = FakeCache()
+    refreshed: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/inside/res-ids":
+            return httpx.Response(200, json=[10, 20])
+        if request.method == "POST" and request.url.path.startswith("/inside/cv/"):
+            refreshed.append(int(request.url.path.split("/")[-1]))
+            return httpx.Response(204)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    monkeypatch.setattr(
+        scraper_tasks,
+        "ScraperResIdCache",
+        lambda: fake_cache,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        scraper_tasks, "ScraperClient", lambda: _mock_client(transport), raising=True
+    )
+
+    result = scraper_tasks.scraper_inside_refresh_task.run()
+
+    assert result["status"] == "success"
+    assert result["res_ids_count"] == 2
+    assert result["failed_res_ids"] == []
+    assert result["cache_key"] == scraper_tasks.DEFAULT_RES_IDS_KEY
+    assert fake_cache.stored == [10, 20]
+    assert refreshed == [10, 20]
+
+
+def test_scraper_inside_refresh_task__request_error_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_base_url(monkeypatch, "https://scraper")
+
+    fake_cache = FakeCache()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/inside/res-ids":
+            return httpx.Response(200, json=[10])
+        if request.method == "POST" and request.url.path == "/inside/cv/10":
+            raise httpx.ConnectError("boom", request=request)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    monkeypatch.setattr(
+        scraper_tasks,
+        "ScraperResIdCache",
+        lambda: fake_cache,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        scraper_tasks, "ScraperClient", lambda: _mock_client(transport), raising=True
+    )
+    monkeypatch.setattr(
+        scraper_tasks.scraper_inside_refresh_task,
+        "retry",
+        DummyTask().retry,
+        raising=True,
+    )
+
+    with pytest.raises(RetryCalled):
+        scraper_tasks.scraper_inside_refresh_task.run()
+
+
+def test_scraper_availability_csv_refresh_task__calls_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_base_url(monkeypatch, "https://scraper")
+
+    called: dict[str, Any] = {"availability": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/availability/csv":
+            called["availability"] = True
+            return httpx.Response(204)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    monkeypatch.setattr(
+        scraper_tasks, "ScraperClient", lambda: _mock_client(transport), raising=True
+    )
+
+    result = scraper_tasks.scraper_availability_csv_refresh_task.run()
+
+    assert result == {"status": "success"}
+    assert called["availability"] is True
+
+
+def test_scraper_reskilling_csv_refresh_task__returns_failed_on_status_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_base_url(monkeypatch, "https://scraper")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/reskilling/csv":
+            return httpx.Response(400, request=request)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    monkeypatch.setattr(
+        scraper_tasks, "ScraperClient", lambda: _mock_client(transport), raising=True
+    )
+
+    result = scraper_tasks.scraper_reskilling_csv_refresh_task.run()
+
+    assert result["status"] == "failed"
+    assert "400" in result["reason"]

--- a/tests/test_workflow_loader.py
+++ b/tests/test_workflow_loader.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.core.workflows.loader import load_workflow
+
+
+def test_load_workflow__yaml__returns_definition(tmp_path: Path) -> None:
+    workflow_path = tmp_path / "workflow.yaml"
+    workflow_path.write_text(
+        """version: 1
+workflow_id: res_id_ingestion
+schedule: "0 */4 * * *"
+
+nodes:
+  - id: fetch_res_ids
+    task: src.services.scraper.tasks.scraper_inside_refresh_task
+""",
+        encoding="utf-8",
+    )
+
+    definition = load_workflow(workflow_path)
+
+    assert definition.workflow_id == "res_id_ingestion"
+    assert definition.schedule == "0 */4 * * *"
+    assert [node.id for node in definition.nodes] == ["fetch_res_ids"]
+
+
+def test_load_workflow__unsupported_extension__raises_value_error(
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / "workflow.txt"
+    workflow_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported workflow file type"):
+        load_workflow(workflow_path)
+
+
+def test_load_workflow__missing_file__raises_file_not_found_error(
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / "missing.yaml"
+
+    with pytest.raises(FileNotFoundError, match="Workflow file not found"):
+        load_workflow(workflow_path)

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.workflows.runner import WorkflowRunner
+from src.core.workflows.schemas import FanoutConfig, WorkflowDefinition, WorkflowNode
+
+
+def test_build_canvas__linear_dependencies__creates_chain() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="workflow",
+        nodes=[
+            WorkflowNode(id="step_a", task="tasks.a"),
+            WorkflowNode(id="step_b", task="tasks.b", depends_on=["step_a"]),
+        ],
+    )
+
+    canvas = WorkflowRunner().build_canvas(definition)
+
+    assert hasattr(canvas, "tasks")
+    assert len(canvas.tasks) == 2
+    assert canvas.tasks[0].task == "tasks.a"
+    assert canvas.tasks[1].task == "tasks.b"
+
+
+def test_build_canvas__cyclic_dependencies__raises_value_error() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="workflow",
+        nodes=[
+            WorkflowNode(id="step_a", task="tasks.a", depends_on=["step_b"]),
+            WorkflowNode(id="step_b", task="tasks.b", depends_on=["step_a"]),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="cyclic"):
+        WorkflowRunner().build_canvas(definition)
+
+
+def test_build_canvas__fanout_node__adds_fanout_kwargs() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="workflow",
+        nodes=[
+            WorkflowNode(
+                id="step_a",
+                task="tasks.a",
+                fanout=FanoutConfig(
+                    source="redis:cache",
+                    task="tasks.child",
+                ),
+            )
+        ],
+    )
+
+    canvas = WorkflowRunner().build_canvas(definition)
+
+    assert canvas.task == "tasks.a"
+    assert canvas.kwargs["fanout_source"] == "redis:cache"
+    assert canvas.kwargs["fanout_task"] == "tasks.child"
+    assert canvas.kwargs["fanout_parameter_name"] == "res_id"

--- a/tests/test_workflow_tasks.py
+++ b/tests/test_workflow_tasks.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.core.workflows.schemas import WorkflowDefinition, WorkflowNode
+from src.services.workflows import tasks as workflow_tasks
+
+
+class DummyResult:
+    def __init__(self, task_id: str) -> None:
+        self.id = task_id
+
+
+class DummyRunner:
+    def __init__(self, *, app=None) -> None:
+        self._app = app
+
+    def run(self, definition: WorkflowDefinition) -> DummyResult:
+        return DummyResult("root-task-id")
+
+
+def test_run_scraper_workflow_task__triggers_canvas(monkeypatch) -> None:
+    definition = WorkflowDefinition(
+        workflow_id="workflow",
+        nodes=[WorkflowNode(id="step_a", task="tasks.a")],
+    )
+
+    monkeypatch.setattr(
+        workflow_tasks,
+        "load_workflow",
+        lambda _: definition,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        workflow_tasks,
+        "WorkflowRunner",
+        DummyRunner,
+        raising=True,
+    )
+
+    result = workflow_tasks.run_scraper_workflow_task(
+        workflow_path=str(Path("config/workflows/res_id_workflow.yaml"))
+    )
+
+    assert result["status"] == "triggered"
+    assert result["workflow_id"] == "workflow"
+    assert result["root_task_id"] == "root-task-id"
+    assert result["node_count"] == 1
+
+
+class DummyGroupResult:
+    def __init__(self, group_id: str, children: list[DummyResult]) -> None:
+        self.id = group_id
+        self.children = children
+
+
+class DummySignature:
+    def __init__(self, task_name: str, kwargs: dict[str, object]) -> None:
+        self.task = task_name
+        self.kwargs = kwargs
+
+
+class DummyGroup:
+    def __init__(self, signatures: list[DummySignature]) -> None:
+        self._signatures = signatures
+
+    def apply_async(self) -> DummyGroupResult:
+        children = [DummyResult(f"child-{index}") for index, _ in enumerate(self._signatures)]
+        return DummyGroupResult("group-123", children)
+
+
+def _make_signature(task_name: str, kwargs: dict[str, object]) -> DummySignature:
+    return DummySignature(task_name, kwargs)
+
+
+def test_run_workflow_fanout_task__uses_cached_res_ids(monkeypatch) -> None:
+    monkeypatch.setattr(
+        workflow_tasks,
+        "_load_fanout_res_ids",
+        lambda _: [101, 202],
+        raising=True,
+    )
+    monkeypatch.setattr(
+        workflow_tasks,
+        "signature",
+        _make_signature,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        workflow_tasks,
+        "group",
+        lambda signatures: DummyGroup(list(signatures)),
+        raising=True,
+    )
+
+    result = workflow_tasks.run_workflow_fanout_task(
+        fanout_source="redis:profilebot:scraper:inside:res_ids",
+        fanout_task="tasks.child",
+        fanout_parameter_name="res_id",
+    )
+
+    assert result["status"] == "triggered"
+    assert result["res_ids_count"] == 2
+    assert result["group_id"] == "group-123"
+    assert result["child_task_ids"] == ["child-0", "child-1"]
+
+
+def test_run_workflow_fanout_task__skips_when_empty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        workflow_tasks,
+        "_load_fanout_res_ids",
+        lambda _: [],
+        raising=True,
+    )
+
+    result = workflow_tasks.run_workflow_fanout_task(
+        fanout_source="redis:profilebot:scraper:inside:res_ids",
+        fanout_task="tasks.child",
+        fanout_parameter_name="res_id",
+    )
+
+    assert result == {"status": "skipped", "res_ids_count": 0}
+
+
+def test_run_workflow_fanout_task__invalid_source_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unsupported fanout source"):
+        workflow_tasks.run_workflow_fanout_task(
+            fanout_source="http:profilebot:scraper:inside:res_ids",
+            fanout_task="tasks.child",
+            fanout_parameter_name="res_id",
+        )
+
+
+def test_run_workflow_fanout_task__empty_source_key_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Fanout source key is required"):
+        workflow_tasks.run_workflow_fanout_task(
+            fanout_source="redis:",
+            fanout_task="tasks.child",
+            fanout_parameter_name="res_id",
+        )


### PR DESCRIPTION
## Summary
- add declarative workflow schema, loader, runner, and Celery orchestration for scraper refresh jobs
- define scraper workflow configuration and schedule override via `SCRAPER_WORKFLOW_PATH`
- add scraper client/cache/tasks plus tests and documentation updates

## Testing
- `ruff`
- `ruff-format`
- `mypy`
- `bandit`
