### PR TITLE
feat(llm): add knowledge profile builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev lint lint-all format format-check preflight test clean run worker beat flower docker-up docker-down api-lint
+.PHONY: help install dev lint lint-all format format-check preflight test clean run worker beat flower docker-up docker-down docker-logs system system-down api-lint
 
 # Default target
 help:
@@ -27,6 +27,9 @@ help:
 	@echo "  make flower      Start Flower dashboard"
 	@echo "  make docker-up   Start Qdrant + Redis"
 	@echo "  make docker-down Stop Docker services"
+	@echo "  make docker-logs Tail Docker logs"
+	@echo "  make system      Start full stack (docker + api + worker + beat + flower)"
+	@echo "  make system-down Stop full stack (docker + api + worker + beat + flower)"
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean       Remove cache and build files"
@@ -124,6 +127,25 @@ docker-up:
 docker-down:
 	@echo "🛑 Stopping Docker services..."
 	docker-compose down
+
+docker-logs:
+	@echo "📜 Tailing Docker logs..."
+	docker-compose logs -f --tail=200
+
+system: docker-up
+	@echo "🚀 Starting full ProfileBot stack (Ctrl+C to stop)..."
+	@uv run uvicorn src.api.main:app --reload --host 0.0.0.0 --port 8000 & \
+	uv run celery -A src.services.embedding.celery_app worker -l info -c 4 & \
+	uv run celery -A src.services.embedding.celery_app beat -l info & \
+	uv run celery -A src.services.embedding.celery_app flower --port=5555 & \
+	wait
+
+system-down: docker-down
+	@echo "🛑 Stopping local ProfileBot processes..."
+	@pkill -f "uvicorn src.api.main:app" || true
+	@pkill -f "celery -A src.services.embedding.celery_app worker" || true
+	@pkill -f "celery -A src.services.embedding.celery_app beat" || true
+	@pkill -f "celery -A src.services.embedding.celery_app flower" || true
 
 # ============== Cleanup ==============
 

--- a/src/core/knowledge_profile/__init__.py
+++ b/src/core/knowledge_profile/__init__.py
@@ -1,0 +1,28 @@
+"""Knowledge Profile package exports."""
+
+from .builder import KPBuilder
+from .ic_sub_state import calculate_ic_sub_state
+from .schemas import (
+    AvailabilityDetail,
+    ExperienceSnapshot,
+    ICSubState,
+    KnowledgeProfile,
+    RelevantChunk,
+    ReskillingPath,
+    SkillDetail,
+)
+from .serializer import KPContextSerializer, KPContextSerializerConfig
+
+__all__ = [
+    "AvailabilityDetail",
+    "ExperienceSnapshot",
+    "ICSubState",
+    "KPBuilder",
+    "KPContextSerializer",
+    "KPContextSerializerConfig",
+    "KnowledgeProfile",
+    "RelevantChunk",
+    "ReskillingPath",
+    "SkillDetail",
+    "calculate_ic_sub_state",
+]

--- a/src/core/knowledge_profile/builder.py
+++ b/src/core/knowledge_profile/builder.py
@@ -1,0 +1,325 @@
+"""Knowledge Profile builder and aggregation logic."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Iterable
+from datetime import date
+from pathlib import Path
+from typing import Protocol
+
+from src.core.knowledge_profile.ic_sub_state import calculate_ic_sub_state
+from src.core.knowledge_profile.schemas import (
+    AvailabilityDetail,
+    ExperienceSnapshot,
+    KnowledgeProfile,
+    ReskillingPath,
+    SkillDetail,
+)
+from src.core.parser.schemas import ParsedCV
+from src.core.seniority.calculator import (
+    calculate_seniority_bucket,
+    calculate_total_experience_years,
+)
+from src.core.skills.dictionary import SkillDictionary, load_skill_dictionary
+from src.core.skills.schemas import SkillExtractionResult
+from src.services.availability.schemas import AvailabilityStatus, ProfileAvailability
+from src.services.availability.service import AvailabilityService
+from src.services.reskilling.schemas import ReskillingRecord, ReskillingStatus
+from src.services.reskilling.service import ReskillingService
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DICTIONARY_PATH = Path("data/skills_dictionary.yaml")
+_DESCRIPTION_MAX_CHARS = 200
+
+
+class AvailabilityServiceProtocol(Protocol):
+    def get(self, res_id: int) -> ProfileAvailability | None: ...
+
+
+class ReskillingServiceProtocol(Protocol):
+    def get(self, res_id: int) -> ReskillingRecord | None: ...
+
+
+class KPBuilder:
+    """Builder for Knowledge Profile aggregation."""
+
+    def __init__(
+        self,
+        availability_service: AvailabilityServiceProtocol | None = None,
+        reskilling_service: ReskillingServiceProtocol | None = None,
+        dictionary: SkillDictionary | None = None,
+    ) -> None:
+        self._availability_service = availability_service or AvailabilityService()
+        self._reskilling_service = reskilling_service or ReskillingService()
+        self._dictionary = dictionary or load_skill_dictionary(_DEFAULT_DICTIONARY_PATH)
+
+    def build(  # noqa: PLR0913
+        self,
+        *,
+        cv_id: str,
+        res_id: int,
+        parsed_cv: ParsedCV,
+        skill_result: SkillExtractionResult,
+        query_skills: Iterable[str] | None = None,
+        match_score: float = 0.0,
+    ) -> KnowledgeProfile:
+        """Build a KnowledgeProfile from parsed data and extracted skills.
+
+        Args:
+            cv_id: CV identifier.
+            res_id: Resource identifier.
+            parsed_cv: Parsed CV data.
+            skill_result: Skill extraction output.
+            query_skills: Optional query skills for match metadata.
+            match_score: Optional match score provided by upstream search.
+
+        Returns:
+            KnowledgeProfile instance.
+        """
+        availability = self._safe_get_availability(res_id)
+        reskilling_records = self._safe_get_reskilling_records(res_id)
+        reskilling_paths = self._build_reskilling_paths(reskilling_records)
+
+        skills = self._build_skill_details(skill_result, reskilling_records)
+        skill_domains = self._count_skill_domains(skills)
+
+        years_experience = calculate_total_experience_years(parsed_cv.experiences)
+        role_titles = [
+            title
+            for title in (
+                parsed_cv.metadata.current_role,
+                *[item.role for item in parsed_cv.experiences],
+            )
+            if title
+        ]
+        seniority_bucket = calculate_seniority_bucket(
+            years_experience,
+            skill_result.skill_count,
+            role_titles,
+        )
+
+        matched_skills, missing_skills, match_ratio = self._build_match_stats(
+            query_skills=query_skills,
+            skills=skills,
+        )
+
+        ic_sub_state = calculate_ic_sub_state(
+            availability,
+            reskilling_records,
+            is_in_transition=False,
+        )
+
+        return KnowledgeProfile(
+            cv_id=cv_id,
+            res_id=res_id,
+            full_name=parsed_cv.metadata.full_name,
+            current_role=parsed_cv.metadata.current_role,
+            skills=skills,
+            skill_domains=skill_domains,
+            total_skills=len(skills),
+            unknown_skills=skill_result.unknown_skills,
+            seniority_bucket=seniority_bucket,
+            years_experience_estimate=years_experience,
+            availability=self._build_availability_detail(availability),
+            ic_sub_state=ic_sub_state,
+            reskilling_paths=reskilling_paths,
+            has_active_reskilling=any(path.is_active for path in reskilling_paths),
+            experiences=self._build_experiences(parsed_cv, skills),
+            relevant_chunks=[],
+            match_score=match_score,
+            matched_skills=matched_skills,
+            missing_skills=missing_skills,
+            match_ratio=match_ratio,
+        )
+
+    def _safe_get_availability(self, res_id: int) -> ProfileAvailability | None:
+        try:
+            return self._availability_service.get(res_id)
+        except Exception as exc:
+            logger.warning("Availability lookup failed for res_id '%s': %s", res_id, exc)
+            return None
+
+    def _safe_get_reskilling_records(self, res_id: int) -> list[ReskillingRecord]:
+        try:
+            record = self._reskilling_service.get(res_id)
+        except Exception as exc:
+            logger.warning("Reskilling lookup failed for res_id '%s': %s", res_id, exc)
+            return []
+        return [record] if record is not None else []
+
+    def _build_availability_detail(
+        self,
+        availability: ProfileAvailability | None,
+    ) -> AvailabilityDetail | None:
+        if availability is None:
+            return None
+        is_intercontratto = availability.allocation_pct == 0 and availability.status in (
+            AvailabilityStatus.FREE,
+            AvailabilityStatus.UNAVAILABLE,
+        )
+        return AvailabilityDetail(
+            status=availability.status,
+            allocation_pct=availability.allocation_pct,
+            current_project=availability.current_project,
+            available_from=availability.available_from,
+            available_to=availability.available_to,
+            manager_name=availability.manager_name,
+            is_intercontratto=is_intercontratto,
+        )
+
+    def _build_reskilling_paths(
+        self,
+        records: Iterable[ReskillingRecord],
+    ) -> list[ReskillingPath]:
+        paths: list[ReskillingPath] = []
+        for record in records:
+            target_skills = [record.skill_target] if record.skill_target else []
+            completion_pct = record.completion_pct or 0
+            paths.append(
+                ReskillingPath(
+                    course_name=record.course_name,
+                    target_skills=target_skills,
+                    completion_pct=completion_pct,
+                    provider=record.provider,
+                    start_date=record.start_date,
+                    end_date=record.end_date,
+                    is_active=record.status == ReskillingStatus.IN_PROGRESS,
+                )
+            )
+        return paths
+
+    def _build_skill_details(
+        self,
+        skill_result: SkillExtractionResult,
+        reskilling_records: Iterable[ReskillingRecord],
+    ) -> list[SkillDetail]:
+        skills: list[SkillDetail] = []
+        for normalized in skill_result.normalized_skills:
+            entry = self._dictionary.get_by_canonical(normalized.canonical)
+            domain = entry.domain if entry else normalized.domain
+            certifications = entry.certifications if entry else []
+            skills.append(
+                SkillDetail(
+                    canonical=normalized.canonical,
+                    domain=domain,
+                    confidence=normalized.confidence,
+                    match_type=normalized.match_type,
+                    source="cv",
+                    reskilling_completion_pct=None,
+                    related_certifications=certifications,
+                    last_used_hint=None,
+                )
+            )
+
+        for record in reskilling_records:
+            if not record.skill_target:
+                continue
+            canonical = record.skill_target.strip().lower()
+            if not canonical:
+                continue
+            entry = self._dictionary.get_by_canonical(canonical)
+            domain = entry.domain if entry else "unknown"
+            certifications = entry.certifications if entry else []
+            completion_pct = record.completion_pct or 0
+            confidence = completion_pct / 100 if completion_pct else 0.0
+            skills.append(
+                SkillDetail(
+                    canonical=canonical,
+                    domain=domain,
+                    confidence=confidence,
+                    match_type="exact",
+                    source="reskilling",
+                    reskilling_completion_pct=completion_pct,
+                    related_certifications=certifications,
+                    last_used_hint=None,
+                )
+            )
+
+        return skills
+
+    def _count_skill_domains(self, skills: Iterable[SkillDetail]) -> dict[str, int]:
+        counter = Counter(skill.domain for skill in skills if skill.domain)
+        return dict(counter)
+
+    def _build_match_stats(
+        self,
+        *,
+        query_skills: Iterable[str] | None,
+        skills: Iterable[SkillDetail],
+    ) -> tuple[list[str], list[str], float]:
+        if not query_skills:
+            return [], [], 0.0
+        normalized_query = [skill.strip().lower() for skill in query_skills if skill.strip()]
+        if not normalized_query:
+            return [], [], 0.0
+        available = {skill.canonical for skill in skills}
+        matched = [skill for skill in normalized_query if skill in available]
+        missing = [skill for skill in normalized_query if skill not in available]
+        match_ratio = len(matched) / len(normalized_query)
+        return matched, missing, match_ratio
+
+    def _build_experiences(
+        self,
+        parsed_cv: ParsedCV,
+        skills: Iterable[SkillDetail],
+    ) -> list[ExperienceSnapshot]:
+        canonical_skills = [skill.canonical for skill in skills]
+        snapshots: list[ExperienceSnapshot] = []
+        for experience in parsed_cv.experiences:
+            period = self._format_period(
+                experience.start_date,
+                experience.end_date,
+                experience.is_current,
+            )
+            description_summary = self._summarize_description(experience.description)
+            related_skills = self._extract_related_skills(
+                experience.description,
+                canonical_skills,
+            )
+            snapshots.append(
+                ExperienceSnapshot(
+                    company=experience.company,
+                    role=experience.role,
+                    period=period,
+                    description_summary=description_summary,
+                    related_skills=related_skills,
+                )
+            )
+        return snapshots
+
+    def _format_period(
+        self,
+        start_date: date | None,
+        end_date: date | None,
+        is_current: bool,
+    ) -> str:
+        if start_date and end_date:
+            return f"{start_date.year}-{end_date.year}"
+        if start_date and is_current:
+            return f"{start_date.year}-oggi"
+        if start_date:
+            return f"{start_date.year}-"
+        return "N/A"
+
+    def _summarize_description(self, description: str) -> str:
+        cleaned = description.strip()
+        if not cleaned:
+            return ""
+        if len(cleaned) <= _DESCRIPTION_MAX_CHARS:
+            return cleaned
+        return f"{cleaned[:_DESCRIPTION_MAX_CHARS].rstrip()}..."
+
+    def _extract_related_skills(
+        self,
+        description: str,
+        canonical_skills: Iterable[str],
+    ) -> list[str]:
+        text = description.lower()
+        related = [skill for skill in canonical_skills if skill in text]
+        return list(dict.fromkeys(related))
+
+
+__all__ = ["KPBuilder"]

--- a/src/core/knowledge_profile/ic_sub_state.py
+++ b/src/core/knowledge_profile/ic_sub_state.py
@@ -1,0 +1,44 @@
+"""IC sub-state calculator for Knowledge Profile."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.core.knowledge_profile.schemas import ICSubState
+from src.services.availability.schemas import AvailabilityStatus, ProfileAvailability
+from src.services.reskilling.schemas import ReskillingRecord, ReskillingStatus
+
+
+def calculate_ic_sub_state(
+    availability: ProfileAvailability | None,
+    reskilling_records: Iterable[ReskillingRecord],
+    *,
+    is_in_transition: bool,
+) -> ICSubState | None:
+    """Calculate IC sub-state for a resource.
+
+    Args:
+        availability: Availability record for the resource, if any.
+        reskilling_records: Reskilling records for the resource.
+        is_in_transition: Whether the resource is in a transition phase.
+
+    Returns:
+        The IC sub-state when applicable, otherwise None.
+    """
+    if availability is None:
+        return None
+    if availability.allocation_pct > 0:
+        return None
+    if availability.status not in (AvailabilityStatus.FREE, AvailabilityStatus.UNAVAILABLE):
+        return None
+
+    if is_in_transition:
+        return ICSubState.IC_IN_TRANSITION
+
+    if any(record.status == ReskillingStatus.IN_PROGRESS for record in reskilling_records):
+        return ICSubState.IC_IN_RESKILLING
+
+    return ICSubState.IC_AVAILABLE
+
+
+__all__ = ["calculate_ic_sub_state"]

--- a/src/core/knowledge_profile/schemas.py
+++ b/src/core/knowledge_profile/schemas.py
@@ -1,0 +1,124 @@
+"""Schemas for Knowledge Profile assembly."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from src.core.seniority.calculator import SeniorityBucket
+from src.services.availability.schemas import AvailabilityStatus
+
+
+class ICSubState(StrEnum):
+    """IC (intercontratto) sub-state values."""
+
+    IC_AVAILABLE = "ic_available"
+    IC_IN_RESKILLING = "ic_in_reskilling"
+    IC_IN_TRANSITION = "ic_in_transition"
+
+
+class SkillDetail(BaseModel):
+    """Skill enriched for Knowledge Profile context."""
+
+    canonical: str
+    domain: str
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    match_type: Literal["exact", "alias", "fuzzy"]
+    source: Literal["cv", "reskilling"]
+    reskilling_completion_pct: int | None = Field(default=None, ge=0, le=100)
+    related_certifications: list[str] = Field(default_factory=list)
+    last_used_hint: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+
+class AvailabilityDetail(BaseModel):
+    """Availability details for Knowledge Profile."""
+
+    status: AvailabilityStatus
+    allocation_pct: int = Field(..., ge=0, le=100)
+    current_project: str | None = None
+    available_from: date | None = None
+    available_to: date | None = None
+    manager_name: str | None = None
+    is_intercontratto: bool
+
+    model_config = {"extra": "forbid"}
+
+
+class ReskillingPath(BaseModel):
+    """Reskilling path metadata for Knowledge Profile."""
+
+    course_name: str
+    target_skills: list[str]
+    completion_pct: int = Field(default=0, ge=0, le=100)
+    provider: str | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    is_active: bool
+
+    model_config = {"extra": "forbid"}
+
+
+class ExperienceSnapshot(BaseModel):
+    """Experience snapshot for Knowledge Profile."""
+
+    company: str | None
+    role: str | None
+    period: str
+    description_summary: str
+    related_skills: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "forbid"}
+
+
+class RelevantChunk(BaseModel):
+    """Relevant chunk extracted from vector store."""
+
+    text: str
+    source_collection: Literal["cv_skills", "cv_experiences"]
+    similarity_score: float = Field(..., ge=0.0, le=1.0)
+    section_type: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+
+class KnowledgeProfile(BaseModel):
+    """Aggregated Knowledge Profile for LLM context."""
+
+    cv_id: str
+    res_id: int
+    full_name: str | None
+    current_role: str | None
+    skills: list[SkillDetail]
+    skill_domains: dict[str, int]
+    total_skills: int
+    unknown_skills: list[str] = Field(default_factory=list)
+    seniority_bucket: SeniorityBucket
+    years_experience_estimate: int | None = None
+    availability: AvailabilityDetail | None = None
+    ic_sub_state: ICSubState | None = None
+    reskilling_paths: list[ReskillingPath] = Field(default_factory=list)
+    has_active_reskilling: bool = False
+    experiences: list[ExperienceSnapshot] = Field(default_factory=list)
+    relevant_chunks: list[RelevantChunk] = Field(default_factory=list)
+    match_score: float = 0.0
+    matched_skills: list[str] = Field(default_factory=list)
+    missing_skills: list[str] = Field(default_factory=list)
+    match_ratio: float = 0.0
+
+    model_config = {"extra": "forbid"}
+
+
+__all__ = [
+    "AvailabilityDetail",
+    "ExperienceSnapshot",
+    "ICSubState",
+    "KnowledgeProfile",
+    "RelevantChunk",
+    "ReskillingPath",
+    "SkillDetail",
+]

--- a/src/core/knowledge_profile/serializer.py
+++ b/src/core/knowledge_profile/serializer.py
@@ -1,0 +1,192 @@
+"""Knowledge Profile context serializer for LLM consumption."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.knowledge_profile.schemas import KnowledgeProfile, SkillDetail
+
+
+@dataclass(frozen=True)
+class KPContextSerializerConfig:
+    """Configuration for KP context serialization."""
+
+    max_skills_per_domain: int = 10
+    max_experiences: int = 3
+    max_chunks: int = 3
+    max_chunk_chars: int = 300
+
+
+class KPContextSerializer:
+    """Serialize KnowledgeProfile data for the matching scenario."""
+
+    def __init__(
+        self,
+        *,
+        max_skills_per_domain: int = 10,
+        max_experiences: int = 3,
+        max_chunks: int = 3,
+        max_chunk_chars: int = 300,
+    ) -> None:
+        self._max_skills_per_domain = max_skills_per_domain
+        self._max_experiences = max_experiences
+        self._max_chunks = max_chunks
+        self._max_chunk_chars = max_chunk_chars
+
+    def serialize(self, profile: KnowledgeProfile, *, index: int = 1, total: int = 1) -> str:
+        """Serialize a single KnowledgeProfile into a structured text block.
+
+        Args:
+            profile: KnowledgeProfile to serialize.
+            index: Candidate index in batch (1-based).
+            total: Total candidates in batch.
+
+        Returns:
+            Serialized text block for the profile.
+        """
+        lines = [f"═══ CANDIDATO {index}/{total} ═══"]
+        lines.append(f"ID: {profile.cv_id} | Res: {profile.res_id}")
+        lines.append(f"Nome: {profile.full_name or 'N/A'} | Ruolo: {profile.current_role or 'N/A'}")
+        lines.append(
+            f"Seniority: {profile.seniority_bucket} | Anni esperienza: "
+            f"{profile.years_experience_estimate if profile.years_experience_estimate is not None else 'N/A'}"
+        )
+        lines.append(
+            f"Match Score: {profile.match_score:.2f} | Copertura: {profile.match_ratio:.0%}"
+        )
+        lines.append("")
+        lines.append(
+            f"▸ SKILL MATCHATE ({len(profile.matched_skills)}): "
+            f"{', '.join(profile.matched_skills) or 'N/A'}"
+        )
+        lines.append(
+            f"▸ SKILL MANCANTI ({len(profile.missing_skills)}): "
+            f"{', '.join(profile.missing_skills) or 'N/A'}"
+        )
+        lines.append(f"▸ TUTTE LE SKILL ({profile.total_skills}):")
+        lines.extend(self._serialize_skills(profile.skills))
+        lines.append("")
+        lines.extend(self._serialize_availability(profile))
+        lines.append("")
+        lines.extend(self._serialize_reskilling(profile))
+        lines.append("")
+        lines.extend(self._serialize_experiences(profile))
+        lines.append("")
+        lines.extend(self._serialize_chunks(profile))
+        lines.append("═══════════════════════════")
+        return "\n".join(lines)
+
+    def serialize_batch(self, profiles: list[KnowledgeProfile], scenario: str) -> str:
+        """Serialize a batch of profiles for the matching scenario.
+
+        Args:
+            profiles: KnowledgeProfile list to serialize.
+            scenario: Scenario name (only "matching" supported).
+
+        Returns:
+            Serialized batch text.
+        """
+        if scenario != "matching":
+            raise ValueError("Only 'matching' scenario is supported for now")
+        sections = [
+            self.serialize(profile, index=index, total=len(profiles))
+            for index, profile in enumerate(profiles, start=1)
+        ]
+        return "\n\n".join(sections)
+
+    @staticmethod
+    def estimate_tokens(text: str) -> int:
+        """Estimate token usage for a given text.
+
+        Args:
+            text: Input text.
+
+        Returns:
+            Estimated token count.
+        """
+        return len(text) // 4
+
+    def _serialize_skills(self, skills: list[SkillDetail]) -> list[str]:
+        grouped = self._group_skills_by_domain(skills)
+        lines: list[str] = []
+        for domain in sorted(grouped):
+            items = grouped[domain][: self._max_skills_per_domain]
+            formatted = ", ".join(self._format_skill(skill) for skill in items)
+            lines.append(f"  [{domain}] {formatted}" if formatted else f"  [{domain}] N/A")
+        if not lines:
+            return ["  N/A"]
+        return lines
+
+    def _serialize_availability(self, profile: KnowledgeProfile) -> list[str]:
+        if profile.availability is None:
+            return ["▸ DISPONIBILITÀ: N/A"]
+        availability = profile.availability
+        lines = [
+            f"▸ DISPONIBILITÀ: {availability.status} | Allocazione: {availability.allocation_pct}%",
+            f"  Progetto: {availability.current_project or 'N/A'}",
+            f"  Disponibile: {availability.available_from or 'N/A'} → "
+            f"{availability.available_to or 'N/A'}",
+            f"  Manager: {availability.manager_name or 'N/A'}",
+            f"  IC: {availability.is_intercontratto} "
+            f"({profile.ic_sub_state.value if profile.ic_sub_state else 'N/A'})",
+        ]
+        return lines
+
+    def _serialize_reskilling(self, profile: KnowledgeProfile) -> list[str]:
+        if not profile.reskilling_paths:
+            return ["▸ RESKILLING ATTIVO:", "  N/A"]
+        lines = ["▸ RESKILLING ATTIVO:"]
+        for path in profile.reskilling_paths:
+            targets = ", ".join(path.target_skills) or "N/A"
+            end_date = path.end_date or "N/A"
+            lines.append(
+                f"  - {path.course_name} ({path.completion_pct}%, "
+                f"{path.provider or 'N/A'}, scade {end_date})"
+            )
+            lines.append(f"    Target: {targets}")
+        return lines
+
+    def _serialize_experiences(self, profile: KnowledgeProfile) -> list[str]:
+        lines = ["▸ ESPERIENZE RILEVANTI:"]
+        if not profile.experiences:
+            lines.append("  N/A")
+            return lines
+        for index, experience in enumerate(profile.experiences[: self._max_experiences], start=1):
+            lines.append(
+                f"  {index}. [{experience.period}] "
+                f"{experience.role or 'N/A'} @ {experience.company or 'N/A'}"
+            )
+            summary = experience.description_summary or "N/A"
+            lines.append(f'     "{summary}"')
+            skills = ", ".join(experience.related_skills) or "N/A"
+            lines.append(f"     Skills: {skills}")
+        return lines
+
+    def _serialize_chunks(self, profile: KnowledgeProfile) -> list[str]:
+        lines = ["▸ CHUNK CONTESTUALI (se presenti):"]
+        if not profile.relevant_chunks:
+            lines.append("  N/A")
+            return lines
+        for chunk in profile.relevant_chunks[: self._max_chunks]:
+            text = chunk.text.strip()
+            if len(text) > self._max_chunk_chars:
+                text = f"{text[: self._max_chunk_chars].rstrip()}..."
+            lines.append(f'  [similarity: {chunk.similarity_score:.2f}] "{text}"')
+        return lines
+
+    @staticmethod
+    def _group_skills_by_domain(skills: list[SkillDetail]) -> dict[str, list[SkillDetail]]:
+        grouped: dict[str, list[SkillDetail]] = {}
+        for skill in skills:
+            grouped.setdefault(skill.domain, []).append(skill)
+        return grouped
+
+    @staticmethod
+    def _format_skill(skill: SkillDetail) -> str:
+        if skill.source == "reskilling":
+            pct = skill.reskilling_completion_pct or 0
+            return f"{skill.canonical} (reskilling, {pct}%)"
+        return f"{skill.canonical} (cv, {skill.confidence:.2f})"
+
+
+__all__ = ["KPContextSerializer", "KPContextSerializerConfig"]

--- a/tests/core/knowledge_profile/test_builder.py
+++ b/tests/core/knowledge_profile/test_builder.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from src.core.knowledge_profile.builder import KPBuilder
+from src.core.parser.schemas import CVMetadata, ExperienceItem, ParsedCV
+from src.core.skills.dictionary import SkillDictionary, SkillDictionaryMeta, SkillEntry
+from src.core.skills.schemas import NormalizedSkill, SkillExtractionResult
+from src.services.availability.schemas import AvailabilityStatus, ProfileAvailability
+from src.services.reskilling.schemas import ReskillingRecord, ReskillingStatus
+
+
+class _AvailabilityStub:
+    def __init__(self, availability: ProfileAvailability | None) -> None:
+        self._availability = availability
+
+    def get(self, res_id: int) -> ProfileAvailability | None:
+        return self._availability
+
+
+class _AvailabilityFailingStub:
+    def get(self, res_id: int) -> ProfileAvailability | None:
+        raise RuntimeError("availability failure")
+
+
+class _ReskillingStub:
+    def __init__(self, record: ReskillingRecord | None) -> None:
+        self._record = record
+
+    def get(self, res_id: int) -> ReskillingRecord | None:
+        return self._record
+
+
+class _ReskillingFailingStub:
+    def get(self, res_id: int) -> ReskillingRecord | None:
+        raise RuntimeError("reskilling failure")
+
+
+def _dictionary() -> SkillDictionary:
+    meta = SkillDictionaryMeta(
+        version="test",
+        updated_at=None,
+        domains=["backend", "devops", "data"],
+    )
+    skills = {
+        "python": SkillEntry(
+            canonical="python",
+            domain="backend",
+            aliases=["py"],
+            related=["fastapi"],
+            certifications=["pcap"],
+        ),
+        "kubernetes": SkillEntry(
+            canonical="kubernetes",
+            domain="devops",
+            aliases=[],
+            related=[],
+            certifications=["cka"],
+        ),
+    }
+    alias_map = {"py": skills["python"]}
+    return SkillDictionary(meta, skills, alias_map)
+
+
+def _parsed_cv() -> ParsedCV:
+    metadata = CVMetadata(
+        cv_id="cv-1",
+        res_id=123,
+        file_name="cv.pdf",
+        full_name="Ada Lovelace",
+        current_role="Backend Engineer",
+        parsed_at=datetime.now(UTC),
+    )
+    experiences = [
+        ExperienceItem(
+            company="Acme",
+            role="Backend Engineer",
+            start_date=date(2020, 1, 1),
+            end_date=date(2022, 1, 1),
+            description="Built Python services with FastAPI and PostgreSQL.",
+            is_current=False,
+        ),
+    ]
+    return ParsedCV(
+        metadata=metadata,
+        skills=None,
+        experiences=experiences,
+        education=[],
+        certifications=[],
+        raw_text="",
+    )
+
+
+def _skill_result() -> SkillExtractionResult:
+    return SkillExtractionResult(
+        cv_id="cv-1",
+        normalized_skills=[
+            NormalizedSkill(
+                original="Python",
+                canonical="python",
+                domain="backend",
+                confidence=0.95,
+                match_type="exact",
+            )
+        ],
+        unknown_skills=["fortran"],
+        dictionary_version="v1",
+    )
+
+
+def _availability() -> ProfileAvailability:
+    return ProfileAvailability(
+        res_id=123,
+        status=AvailabilityStatus.FREE,
+        allocation_pct=0,
+        current_project=None,
+        available_from=date(2024, 1, 1),
+        available_to=None,
+        manager_name="Manager",
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _reskilling() -> ReskillingRecord:
+    return ReskillingRecord(
+        res_id=123,
+        course_name="Kubernetes Fundamentals",
+        skill_target="kubernetes",
+        status=ReskillingStatus.IN_PROGRESS,
+        start_date=date(2024, 1, 1),
+        end_date=None,
+        provider="CloudAcademy",
+        completion_pct=70,
+    )
+
+
+def test_kp_builder__full_data__builds_profile() -> None:
+    builder = KPBuilder(
+        availability_service=_AvailabilityStub(_availability()),
+        reskilling_service=_ReskillingStub(_reskilling()),
+        dictionary=_dictionary(),
+    )
+
+    profile = builder.build(
+        cv_id="cv-1",
+        res_id=123,
+        parsed_cv=_parsed_cv(),
+        skill_result=_skill_result(),
+        query_skills=["python", "kubernetes", "aws"],
+        match_score=0.82,
+    )
+
+    assert profile.cv_id == "cv-1"
+    assert profile.res_id == 123
+    assert profile.total_skills == 2
+    assert profile.unknown_skills == ["fortran"]
+    assert profile.availability is not None
+    assert profile.availability.is_intercontratto is True
+    assert profile.ic_sub_state is not None
+    assert profile.reskilling_paths
+    assert profile.has_active_reskilling is True
+    assert profile.matched_skills == ["python", "kubernetes"]
+    assert profile.missing_skills == ["aws"]
+    assert profile.match_ratio == pytest.approx(2 / 3)
+    assert profile.match_score == pytest.approx(0.82)
+
+
+def test_kp_builder__graceful_degradation__returns_partial_profile() -> None:
+    builder = KPBuilder(
+        availability_service=_AvailabilityFailingStub(),
+        reskilling_service=_ReskillingFailingStub(),
+        dictionary=_dictionary(),
+    )
+
+    profile = builder.build(
+        cv_id="cv-1",
+        res_id=123,
+        parsed_cv=_parsed_cv(),
+        skill_result=_skill_result(),
+    )
+
+    assert profile.availability is None
+    assert profile.reskilling_paths == []
+    assert profile.has_active_reskilling is False
+
+
+def test_kp_builder__minimal_inputs__still_builds_profile() -> None:
+    builder = KPBuilder(
+        availability_service=_AvailabilityStub(None),
+        reskilling_service=_ReskillingStub(None),
+        dictionary=_dictionary(),
+    )
+
+    profile = builder.build(
+        cv_id="cv-1",
+        res_id=123,
+        parsed_cv=_parsed_cv(),
+        skill_result=_skill_result(),
+        query_skills=[],
+    )
+
+    assert profile.match_ratio == 0.0
+    assert profile.matched_skills == []
+    assert profile.missing_skills == []

--- a/tests/core/knowledge_profile/test_ic_sub_state.py
+++ b/tests/core/knowledge_profile/test_ic_sub_state.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from src.core.knowledge_profile.ic_sub_state import calculate_ic_sub_state
+from src.core.knowledge_profile.schemas import ICSubState
+from src.services.availability.schemas import AvailabilityStatus, ProfileAvailability
+from src.services.reskilling.schemas import ReskillingRecord, ReskillingStatus
+
+
+def _availability(
+    *,
+    status: AvailabilityStatus,
+    allocation_pct: int,
+) -> ProfileAvailability:
+    return ProfileAvailability(
+        res_id=123,
+        status=status,
+        allocation_pct=allocation_pct,
+        current_project=None,
+        available_from=None,
+        available_to=None,
+        manager_name=None,
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _reskilling(status: ReskillingStatus) -> ReskillingRecord:
+    return ReskillingRecord(
+        res_id=123,
+        course_name="Course",
+        skill_target="kubernetes",
+        status=status,
+        start_date=None,
+        end_date=None,
+        provider=None,
+        completion_pct=50,
+    )
+
+
+def test_calculate_ic_sub_state__not_ic__returns_none() -> None:
+    availability = _availability(status=AvailabilityStatus.PARTIAL, allocation_pct=50)
+
+    result = calculate_ic_sub_state(
+        availability,
+        [],
+        is_in_transition=False,
+    )
+
+    assert result is None
+
+
+def test_calculate_ic_sub_state__ic_available__returns_available() -> None:
+    availability = _availability(status=AvailabilityStatus.FREE, allocation_pct=0)
+
+    result = calculate_ic_sub_state(
+        availability,
+        [],
+        is_in_transition=False,
+    )
+
+    assert result == ICSubState.IC_AVAILABLE
+
+
+def test_calculate_ic_sub_state__ic_in_reskilling__returns_reskilling() -> None:
+    availability = _availability(status=AvailabilityStatus.FREE, allocation_pct=0)
+    records = [_reskilling(ReskillingStatus.IN_PROGRESS)]
+
+    result = calculate_ic_sub_state(
+        availability,
+        records,
+        is_in_transition=False,
+    )
+
+    assert result == ICSubState.IC_IN_RESKILLING
+
+
+def test_calculate_ic_sub_state__ic_in_transition__has_priority() -> None:
+    availability = _availability(status=AvailabilityStatus.UNAVAILABLE, allocation_pct=0)
+    records = [_reskilling(ReskillingStatus.IN_PROGRESS)]
+
+    result = calculate_ic_sub_state(
+        availability,
+        records,
+        is_in_transition=True,
+    )
+
+    assert result == ICSubState.IC_IN_TRANSITION

--- a/tests/core/knowledge_profile/test_serializer.py
+++ b/tests/core/knowledge_profile/test_serializer.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.core.knowledge_profile.schemas import (
+    AvailabilityDetail,
+    ExperienceSnapshot,
+    KnowledgeProfile,
+    RelevantChunk,
+    ReskillingPath,
+    SkillDetail,
+)
+from src.core.knowledge_profile.serializer import KPContextSerializer
+from src.services.availability.schemas import AvailabilityStatus
+
+
+def _profile() -> KnowledgeProfile:
+    return KnowledgeProfile(
+        cv_id="cv-1",
+        res_id=123,
+        full_name="Ada Lovelace",
+        current_role="Backend Engineer",
+        skills=[
+            SkillDetail(
+                canonical="python",
+                domain="backend",
+                confidence=0.95,
+                match_type="exact",
+                source="cv",
+                reskilling_completion_pct=None,
+                related_certifications=["pcap"],
+                last_used_hint=None,
+            ),
+            SkillDetail(
+                canonical="kubernetes",
+                domain="devops",
+                confidence=0.7,
+                match_type="exact",
+                source="reskilling",
+                reskilling_completion_pct=70,
+                related_certifications=["cka"],
+                last_used_hint=None,
+            ),
+        ],
+        skill_domains={"backend": 1, "devops": 1},
+        total_skills=2,
+        unknown_skills=[],
+        seniority_bucket="mid",
+        years_experience_estimate=4,
+        availability=AvailabilityDetail(
+            status=AvailabilityStatus.FREE,
+            allocation_pct=0,
+            current_project=None,
+            available_from=date(2024, 1, 1),
+            available_to=None,
+            manager_name="Manager",
+            is_intercontratto=True,
+        ),
+        ic_sub_state=None,
+        reskilling_paths=[
+            ReskillingPath(
+                course_name="Kubernetes Fundamentals",
+                target_skills=["kubernetes"],
+                completion_pct=70,
+                provider="CloudAcademy",
+                start_date=date(2024, 1, 1),
+                end_date=None,
+                is_active=True,
+            )
+        ],
+        has_active_reskilling=True,
+        experiences=[
+            ExperienceSnapshot(
+                company="Acme",
+                role="Backend Engineer",
+                period="2020-2022",
+                description_summary="Built Python services with FastAPI.",
+                related_skills=["python"],
+            )
+        ],
+        relevant_chunks=[
+            RelevantChunk(
+                text="Designed microservices with Kafka and Redis.",
+                source_collection="cv_experiences",
+                similarity_score=0.87,
+                section_type="experience",
+            )
+        ],
+        match_score=0.82,
+        matched_skills=["python"],
+        missing_skills=["aws"],
+        match_ratio=0.5,
+    )
+
+
+def test_serialize_batch__matching__renders_expected_sections() -> None:
+    serializer = KPContextSerializer(max_skills_per_domain=5, max_experiences=2, max_chunks=2)
+    output = serializer.serialize_batch([_profile()], scenario="matching")
+
+    assert "═══ CANDIDATO 1/1 ═══" in output
+    assert "▸ SKILL MATCHATE" in output
+    assert "▸ SKILL MANCANTI" in output
+    assert "▸ TUTTE LE SKILL" in output
+    assert "▸ DISPONIBILITÀ" in output
+    assert "▸ RESKILLING ATTIVO" in output
+    assert "▸ ESPERIENZE RILEVANTI" in output
+    assert "▸ CHUNK CONTESTUALI" in output
+
+
+def test_estimate_tokens__length_based__returns_quarter_length() -> None:
+    text = "abcd" * 10
+    assert KPContextSerializer.estimate_tokens(text) == len(text) // 4


### PR DESCRIPTION
## Summary
- add Knowledge Profile schemas, builder, IC sub-state calculator, and serializer
- add Knowledge Profile tests (builder, serializer, IC sub-state)
- extend Makefile with `docker-logs`, `system`, and `system-down` targets

## Testing
- `make test` *(fails: `tests/test_qdrant_connection.py` — Qdrant not reachable)*