### PR TITLE
[TD-005] Automazione embedding nel workflow ingestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev lint lint-all format format-check preflight test clean run worker beat flower docker-build docker-up docker-down docker-logs system system-down api-lint system-test
+.PHONY: help install dev lint lint-all format format-check preflight test clean run worker beat flower embed-all docker-build docker-up docker-down docker-logs system system-down api-lint system-test
 
 # Default target
 help:
@@ -26,6 +26,7 @@ help:
 	@echo "  make worker      Start Celery worker"
 	@echo "  make beat        Start Celery beat scheduler"
 	@echo "  make flower      Start Flower dashboard"
+	@echo "  make embed-all   Trigger embedding from scraper"
 	@echo "  make docker-up   Start Qdrant + Redis"
 	@echo "  make docker-down Stop Docker services"
 	@echo "  make docker-logs Tail Docker logs"
@@ -126,6 +127,10 @@ beat:
 flower:
 	@echo "🌸 Starting Flower dashboard..."
 	uv run celery -A src.services.embedding.celery_app flower --port=5555
+
+embed-all:
+	@echo "🧩 Triggering embedding from scraper..."
+	@uv run python -c 'from src.services.embedding.tasks import embed_from_scraper_task; print(embed_from_scraper_task.run())'
 
 docker-build:
 	@echo "🐳 Building Docker images..."

--- a/config/workflows/res_id_workflow.yaml
+++ b/config/workflows/res_id_workflow.yaml
@@ -19,3 +19,7 @@ nodes:
 
   - id: export_reskilling
     task: src.services.scraper.tasks.scraper_reskilling_csv_refresh_task
+
+  - id: embed_all
+    task: src.services.embedding.tasks.embed_from_scraper_task
+    depends_on: [inside_fanout]

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Product Backlog - ProfileBot MVP
 
-> **Ultimo aggiornamento:** 1 marzo 2026
+> **Ultimo aggiornamento:** 2 marzo 2026
 
 ## Epic 1: Infrastructure Setup
 > Configurazione ambiente e infrastruttura base
@@ -438,50 +438,66 @@ Oggi il payload `cv_skills` in Qdrant contiene solo: `cv_id`, `res_id`, `normali
 **Per** eliminare la dipendenza da task manuali e garantire che Qdrant sia sempre allineato con i CV più recenti
 
 **Contesto:**
-Oggi il workflow `res_id_ingestion` (schedule `0 */4 * * *`) esegue 4 nodi: fetch res_id, fanout refresh CV, export availability CSV, export reskilling CSV. Ma l'embedding in Qdrant è un processo completamente separato, triggerabile solo via API (`POST /api/v1/embeddings/trigger`) passando manualmente la lista `{cv_path, res_id}`. Questo significa che dopo il workflow i file .docx sono aggiornati ma Qdrant resta vuoto o stale. Il gap architetturale è che **nessuno persiste la mappatura `res_id → cv_path`** dopo il refresh: `scraper_inside_refresh_item_task` ritorna `{"status": "success"}` ma non il path del file salvato.
+Oggi il workflow `res_id_ingestion` (schedule `0 */4 * * *`) esegue 4 nodi: fetch res_id, fanout POST per produrre i CV lato scraper, export availability CSV, export reskilling CSV. Ma **nessuno scarica i CV** prodotti e **nessuno li indicizza** in Qdrant. L'embedding è triggerabile solo via API (`POST /api/v1/embeddings/trigger`) passando manualmente una lista `{cv_path, res_id}` che presuppone file su filesystem locale — approccio non coerente con l'architettura a servizi.
+
+Il contratto scraper service prevede due step per i CV:
+- `POST /inside/cv/{res_id}` → **produce** il file DOCX lato scraper (ritorna `{path}` locale al servizio)
+- `GET /inside/cv/{res_id}` → **scarica** il file come bytes binari (`format: binary`)
+
+Oggi ProfileBot esegue solo il POST (via `ScraperClient.refresh_inside_cv`) senza mai fare la GET. Inoltre:
+- `ScraperClient._request()` fa sempre `.json()` → non gestisce risposte binarie
+- `DocxParser.parse()` accetta solo `Path` → non supporta `bytes`/`BytesIO`
+- `_extract_res_id()` estrae il res_id dal filename → impossibile con stream in memoria
+- `_embed_cv()` e `embed_all_task` lavorano solo con file path su filesystem
 
 **Acceptance Criteria:**
 
-_Prerequisito: Discovery CV files_
-- [ ] Definire la convenzione di storage dei CV (es. `data/cv/{res_id}.docx`) oppure arricchire `scraper_inside_refresh_item_task` per salvare la mappatura `res_id → cv_path` in Redis (chiave `profilebot:cv:paths:{res_id}`)
-- [ ] Creare funzione `_discover_cv_files(cv_dir: str) -> list[dict]` che restituisce `[{"cv_path": ..., "res_id": ...}]` tramite glob su directory convenzionale oppure lettura da Redis
+_1. ScraperClient: download CV binario_
+- [x] Nuovo metodo `ScraperClient.download_inside_cv(res_id: int) -> bytes` che fa `GET /inside/cv/{res_id}` e ritorna i bytes grezzi del DOCX
+- [x] `_request()` o nuovo metodo `_request_binary()` che gestisce `Content-Type: application/vnd.openxmlformats-...` senza `.json()`
+- [x] Test unitario: mock httpx → verifica che download_inside_cv ritorna bytes e gestisce 404/500
 
-_Nuovo task Celery_
-- [ ] Creare `embed_from_discovery_task` in `src/services/embedding/tasks.py` che: (a) chiama `_discover_cv_files()`, (b) delega a `embed_all_task` con la lista scoperta, (c) ritorna summary con conteggi
-- [ ] Il task deve essere idempotente: se un CV non è cambiato (stesso file), l'upsert in Qdrant sovrascrive con dati identici (costo: solo API embedding OpenAI)
-- [ ] Opzionale: check `file_hash` (md5 del .docx) vs hash salvato nel payload Qdrant per skip CV non modificati (ottimizzazione futura, non bloccante)
+_2. DocxParser: parsing da bytes in memoria_
+- [x] Nuovo metodo `DocxParser.parse_bytes(data: bytes, res_id: int, filename: str | None = None) -> ParsedCV` che parsa da `BytesIO` senza accesso al filesystem
+- [x] Il `res_id` viene passato come parametro (non estratto dal filename); `filename` è opzionale per metadata
+- [x] `python-docx` supporta nativamente `BytesIO` come input a `Document()`
+- [x] Funzione helper `parse_docx_bytes(data: bytes, res_id: int) -> ParsedCV` (analog a `parse_docx`)
+- [x] Test unitario: bytes di un DOCX valido → `ParsedCV` con res_id corretto; bytes corrotti → `CVParseError`
 
-_Integrazione nel Workflow YAML_
-- [ ] Aggiungere nodo `embed_all` in `config/workflows/res_id_workflow.yaml` con `depends_on: [inside_fanout]`
-- [ ] Il nodo deve usare `task: src.services.embedding.tasks.embed_from_discovery_task`
-- [ ] Verificare che il runner DAG produca la canvas corretta: `chain(group(fetch_res_ids, export_availability, export_reskilling), inside_fanout, embed_all)`
+_3. Embedding task: embed da scraper service_
+- [x] Nuovo task `embed_from_scraper_task` in `src/services/embedding/tasks.py` che: (a) legge lista res_id da Redis (`profilebot:scraper:inside:res_ids`), (b) per ogni res_id chiama `ScraperClient.download_inside_cv(res_id)` → `parse_docx_bytes()` → `SkillExtractor.extract()` → `EmbeddingPipeline.process_cv()`, (c) ritorna summary con conteggi
+- [x] Resilienza: se download o parsing fallisce per un res_id, log + skip, prosegui con i successivi
+- [x] Progress tracking via `self.update_state(state="PROGRESS", meta={...})` come in `embed_all_task`
+- [x] Idempotenza garantita da `_generate_point_id()` deterministico (hash cv_id + section_type) → upsert sovrascrive
 
-_Configurazione_
-- [ ] Aggiungere `cv_storage_dir: str` a `Settings` (default: `data/cv`) con env var `CV_STORAGE_DIR`
-- [ ] Il task legge da `settings.cv_storage_dir`
+_4. Integrazione nel Workflow YAML_
+- [x] Aggiungere nodo `embed_all` in `config/workflows/res_id_workflow.yaml` con `depends_on: [inside_fanout]`
+- [x] Il nodo usa `task: src.services.embedding.tasks.embed_from_scraper_task`
+- [x] Verificare che il runner DAG produca la canvas corretta: i nodi export restano paralleli, `embed_all` dipende da `inside_fanout`
 
-_Test_
-- [ ] Test unitario `_discover_cv_files()`: directory vuota → `[]`, directory con .docx → lista corretta, file non-.docx ignorati
-- [ ] Test unitario `embed_from_discovery_task`: mock discovery + mock `embed_all_task`, verificare che la lista venga passata correttamente
-- [ ] Test integrazione workflow: caricare il YAML aggiornato, verificare che il canvas Celery includa il nodo `embed_all` dopo `inside_fanout`
-- [ ] Test idempotenza: embeddare 2 volte lo stesso CV, verificare che Qdrant contenga 1 solo punto (non duplicati)
+_5. Test_
+- [x] Test unitario `embed_from_scraper_task`: mock ScraperClient + mock EmbeddingPipeline, verificare che il flusso download → parse_bytes → extract → process_cv funzioni per N res_id
+- [x] Test resilienza: 1 res_id su 3 fallisce download → task completa con 2 successi + 1 errore loggato
+- [x] Test idempotenza: mock che verifica che `_generate_point_id()` produce ID stabili → upsert non duplica
+- [x] Test integrazione workflow: caricare il YAML aggiornato, verificare che il canvas Celery includa il nodo `embed_all` dopo `inside_fanout`
 
-_Target Make (opzionale)_
-- [ ] Aggiungere `make embed-all` al Makefile per trigger manuale one-shot (utile per bootstrap iniziale e re-embedding post US-009.5)
+_6. Target Make (opzionale)_
+- [x] Aggiungere `make embed-all` al Makefile che invoca `embed_from_scraper_task` via Celery per trigger manuale one-shot
 
-**Story Points:** 3
+**Story Points:** 5
 **Priority:** P1 - High
-**Status:** 🔜 Sprint 8 — [#57](https://github.com/giamma80/profilebot/issues/57)
-**Ref:** Analisi architetturale 01/03/2026 (workflow engine, embedding pipeline, scraper tasks)
-**Dipendenze:** US-005 ✅, US-016 ✅
+**Status:** ✅ Completata (Sprint 8) — [#57](https://github.com/giamma80/profilebot/issues/57)
+**Ref:** Analisi architetturale 01/03/2026, OpenAPI scraper-service (`docs/scraper-service/scraper-service-openapi.yaml`)
+**Dipendenze:** US-005 ✅, US-016 ✅, US-009.5 ✅
 
 **Note tecniche:**
 - Il workflow engine (`src/core/workflows/`) supporta nativamente il nuovo nodo: `WorkflowNode` con `depends_on`, il runner converte in Celery `chain`/`group`
+- `python-docx` accetta `BytesIO` nativamente: `Document(BytesIO(data))` — zero dipendenze aggiuntive
 - L'embedding pipeline usa `_generate_point_id()` deterministico (hash cv_id + section_type) → upsert idempotente, nessun duplicato
 - Il payload è già arricchito (US-009.5): `full_name`, `current_role`, `skill_details`, `experiences_compact`, `unknown_skills`, `years_experience_estimate`
 - Schedule attuale `0 */4 * * *` (ogni 4 ore) è adeguato anche per l'embedding: il costo aggiuntivo è ~$0.01/CV per embedding OpenAI
-- Per il bootstrap iniziale (prima volta o post US-009.5), usare `make embed-all` o triggerare via API; le esecuzioni successive saranno automatiche via workflow
-- Se lo scraper salva i CV con naming convention `{res_id}.docx`, la discovery è un semplice glob; se il naming è diverso, serve parsing del filename o mappatura Redis
+- Story points aumentati da 3 a 5: il refactor del parser e del client aggiunge complessità rispetto alla versione filesystem-only
+- Non serve `cv_storage_dir` in Settings: i CV vengono scaricati on the fly dal scraper service e parsati in memoria
 
 ---
 
@@ -524,8 +540,8 @@ _Target Make (opzionale)_
 - US-009.5: Arricchimento Payload Qdrant per KP (3 SP) ✅ — [#56](https://github.com/giamma80/profilebot/issues/56)
 - US-009.4: Integrazione KP Context nella Pipeline di Matching (5 SP) ⏳ — [#54](https://github.com/giamma80/profilebot/issues/54) — restano note review non bloccanti
 
-### Sprint 8 — Automazione & Stabilizzazione (2 settimane)
-- TD-005: Automazione Embedding nel Workflow (3 SP) — [#57](https://github.com/giamma80/profilebot/issues/57)
+### Sprint 8 — Automazione & Stabilizzazione (2 settimane) ✅
+- TD-005: Automazione Embedding nel Workflow (5 SP) ✅ — [#57](https://github.com/giamma80/profilebot/issues/57)
 
 ---
 
@@ -534,14 +550,14 @@ _Target Make (opzionale)_
 | Priority | Stories | Total Points | Completati |
 |----------|---------|--------------|-----------|
 | P0 - Critical | 6 | 50 | 50 ✅ |
-| P1 - High | 10 | 57 | 39 ✅ + 5 ⏳ |
+| P1 - High | 10 | 59 | 44 ✅ + 5 ⏳ |
 | P2 - Medium | 6 | 29 | 11 ✅ |
 | P3 - Low | 0 | 0 | 0 |
-| **Total** | **22** | **136** | **100 ✅ + 5 ⏳ (77%)** |
+| **Total** | **22** | **138** | **105 ✅ + 5 ⏳ (80%)** |
 
 **Velocity effettiva:** ~22 SP/sprint (Sprint 1-4 media)
 **Sprint 4 completato:** US-008 (13 SP) + US-009 (8 SP) + US-016 (5 SP) + US-017 (3 SP)
 **Sprint 6 in corso:** US-009.1 ✅ (2) + US-009.2 (5) + US-009.3 (5) + TD-001 (3) + TD-004 (3) = 18 SP (2 completati)
 **Sprint 7 in review:** US-009.5 ✅ (3 SP) + US-009.4 ⏳ (5 SP) = 8 SP — US-009.5 completata, US-009.4 restano note review non bloccanti
-**Sprint 8 pianificato:** TD-005 (3 SP)
+**Sprint 8 completato:** TD-005 ✅ (5 SP)
 **MVP completabile in:** ~1-2 sprint rimanenti

--- a/src/core/parser/__init__.py
+++ b/src/core/parser/__init__.py
@@ -1,6 +1,6 @@
 """Parser module exports."""
 
-from .docx_parser import DocxParser, parse_docx
+from .docx_parser import DocxParser, parse_docx, parse_docx_bytes
 from .metadata_extractor import extract_metadata
 from .schemas import CVMetadata, ExperienceItem, ParsedCV, SkillSection
 from .section_detector import SECTION_PATTERNS, detect_sections
@@ -15,4 +15,5 @@ __all__ = [
     "detect_sections",
     "extract_metadata",
     "parse_docx",
+    "parse_docx_bytes",
 ]

--- a/src/core/parser/docx_parser.py
+++ b/src/core/parser/docx_parser.py
@@ -7,6 +7,7 @@ import re
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
 
 from docx import Document
@@ -75,6 +76,60 @@ class DocxParser:
 
         sections = self._extract_sections(lines, raw_text)
         metadata = self._build_metadata(path, raw_text)
+
+        parsed = ParsedCV(
+            metadata=metadata,
+            skills=self._parse_skills(sections.skills),
+            experiences=self._parse_experiences(sections.experience),
+            education=sections.education,
+            certifications=sections.certifications,
+            raw_text=sections.raw_text,
+        )
+        self._log_parse_result(parsed, sections, start_time)
+        return parsed
+
+    def parse_bytes(self, data: bytes, res_id: int, filename: str | None = None) -> ParsedCV:
+        """Parse a DOCX CV from in-memory bytes.
+
+        Args:
+            data: Raw DOCX bytes.
+            res_id: Resource identifier for the CV.
+            filename: Optional filename to include in metadata.
+
+        Returns:
+            ParsedCV with extracted sections and metadata.
+
+        Raises:
+            CVParseError: If the DOCX bytes are invalid or cannot be parsed.
+        """
+        start_time = time.perf_counter()
+
+        try:
+            document = Document(BytesIO(data))
+        except PackageNotFoundError as exc:
+            raise CVParseError(f"Invalid DOCX bytes for res_id {res_id}") from exc
+        except Exception as exc:  # pragma: no cover - defensive
+            raise CVParseError(f"Failed to read DOCX bytes for res_id {res_id}") from exc
+
+        lines = list(self._extract_lines(document))
+        raw_text = "\n".join(lines).strip()
+        resolved_filename = filename or f"{res_id}_unknown.docx"
+
+        if not raw_text:
+            metadata = self._build_metadata_from_bytes(res_id, resolved_filename, raw_text)
+            parsed = ParsedCV(
+                metadata=metadata,
+                skills=None,
+                experiences=[],
+                education=[],
+                certifications=[],
+                raw_text="",
+            )
+            self._log_parse_result(parsed, ParsedSections([], [], [], [], raw_text), start_time)
+            return parsed
+
+        sections = self._extract_sections(lines, raw_text)
+        metadata = self._build_metadata_from_bytes(res_id, resolved_filename, raw_text)
 
         parsed = ParsedCV(
             metadata=metadata,
@@ -167,6 +222,18 @@ class DocxParser:
             parsed_at=metadata.parsed_at,
         )
 
+    def _build_metadata_from_bytes(self, res_id: int, filename: str, raw_text: str) -> CVMetadata:
+        """Build metadata when res_id is provided explicitly."""
+        metadata = extract_metadata(raw_text)
+        return CVMetadata(
+            cv_id=metadata.cv_id,
+            res_id=res_id,
+            file_name=filename,
+            full_name=metadata.full_name,
+            current_role=metadata.current_role,
+            parsed_at=metadata.parsed_at,
+        )
+
     def _extract_res_id(self, filename: str) -> int:
         """Extract res_id from filename using the {res_id}_ prefix pattern."""
         match = re.match(r"^(\d+)_", filename)
@@ -232,9 +299,14 @@ class DocxParser:
         return tokens
 
 
+def parse_docx_bytes(data: bytes, res_id: int, filename: str | None = None) -> ParsedCV:
+    """Convenience function to parse a DOCX CV from bytes."""
+    return DocxParser().parse_bytes(data, res_id, filename=filename)
+
+
 def parse_docx(file_path: str | Path) -> ParsedCV:
     """Convenience function to parse a DOCX CV file."""
     return DocxParser().parse(file_path)
 
 
-__all__ = ["CVParseError", "DocxParser", "parse_docx"]
+__all__ = ["CVParseError", "DocxParser", "parse_docx", "parse_docx_bytes"]

--- a/src/services/embedding/tasks.py
+++ b/src/services/embedding/tasks.py
@@ -9,9 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from src.core.embedding.pipeline import EmbeddingPipeline
-from src.core.parser import parse_docx
+from src.core.parser import parse_docx, parse_docx_bytes
 from src.core.skills import SkillExtractor, load_skill_dictionary
 from src.services.embedding.celery_app import celery_app
+from src.services.scraper.cache import ScraperResIdCache
+from src.services.scraper.client import ScraperClient
+from src.services.scraper.tasks import _ensure_scraper_base_url
 
 logger = logging.getLogger(__name__)
 
@@ -274,4 +277,70 @@ def embed_all_task(  # noqa: PLR0913 - task signature mirrors API payload
         "errors": errors,
         "percentage": 100,
         "force": force,
+    }
+
+
+@celery_app.task(bind=True)
+def embed_from_scraper_task(self) -> dict[str, Any]:
+    """Download CVs from the scraper service and index them into Qdrant."""
+    if not _ensure_scraper_base_url():
+        return {"status": "skipped", "reason": "SCRAPER_BASE_URL not configured"}
+
+    cache = ScraperResIdCache()
+    res_ids = cache.get_res_ids()
+    if not res_ids:
+        return {
+            "status": "empty",
+            "processed": 0,
+            "failed": 0,
+            "totals": {"cv_skills": 0, "cv_experiences": 0, "total": 0},
+            "errors": [],
+            "percentage": 0,
+        }
+
+    dictionary = load_skill_dictionary(_resolve_dictionary_path(None))
+    extractor = SkillExtractor(dictionary)
+    pipeline = EmbeddingPipeline()
+
+    processed = 0
+    failed = 0
+    totals = {"cv_skills": 0, "cv_experiences": 0, "total": 0}
+    errors: list[dict[str, int | str]] = []
+    total_res_ids = len(res_ids)
+
+    with ScraperClient() as client:
+        for index, res_id in enumerate(res_ids, start=1):
+            try:
+                data = client.download_inside_cv(res_id)
+                parsed_cv = parse_docx_bytes(data, res_id)
+                skill_result = extractor.extract(parsed_cv)
+                result = pipeline.process_cv(parsed_cv, skill_result)
+                totals["cv_skills"] += result.get("cv_skills", 0)
+                totals["cv_experiences"] += result.get("cv_experiences", 0)
+                totals["total"] += result.get("total", 0)
+                processed += 1
+            except Exception as exc:
+                failed += 1
+                errors.append({"res_id": res_id, "error": str(exc)})
+                logger.exception("Failed embedding CV for res_id %s", res_id)
+            finally:
+                percentage = int(index / total_res_ids * 100)
+                if self.request.id is not None:
+                    self.update_state(
+                        state="PROGRESS",
+                        meta={
+                            "percentage": percentage,
+                            "res_id": res_id,
+                            "processed": processed,
+                            "failed": failed,
+                        },
+                    )
+
+    return {
+        "status": "completed",
+        "processed": processed,
+        "failed": failed,
+        "totals": totals,
+        "errors": errors,
+        "percentage": 100,
     }

--- a/src/services/scraper/client.py
+++ b/src/services/scraper/client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -87,6 +87,10 @@ class ScraperClient:
         """Trigger refresh for a single Inside CV."""
         self.post(f"/inside/cv/{res_id}")
 
+    def download_inside_cv(self, res_id: int) -> bytes:
+        """Download the CV DOCX bytes via GET /inside/cv/{res_id}."""
+        return self._request_binary(f"/inside/cv/{res_id}")
+
     def export_availability_csv(self) -> None:
         """Trigger the availability CSV export."""
         self.post("/availability/csv")
@@ -109,6 +113,14 @@ class ScraperClient:
         if not response.content:
             return None
         return response.json()
+
+    def _request_binary(self, path: str) -> bytes:
+        """GET request returning raw bytes for binary content like DOCX."""
+        response = self._client.request("GET", path)
+        response.raise_for_status()
+        if not response.content:
+            raise ValueError(f"Empty response for {path}")
+        return cast(bytes, response.content)
 
 
 __all__ = [

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -91,3 +91,153 @@ def test_embed_cv_task__progress_meta__includes_parsed_res_id(
 
     assert result["res_id"] == 99999
     assert states[-1]["meta"]["res_id"] == 99999
+
+
+def test_embed_from_scraper_task__skips_without_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _missing_base_url() -> None:
+        return None
+
+    monkeypatch.setattr(tasks, "_ensure_scraper_base_url", _missing_base_url, raising=True)
+
+    result = tasks.embed_from_scraper_task.run()
+
+    assert result == {
+        "status": "skipped",
+        "reason": "SCRAPER_BASE_URL not configured",
+    }
+
+
+def test_embed_from_scraper_task__processes_res_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _base_url() -> str:
+        return "https://scraper"
+
+    monkeypatch.setattr(tasks, "_ensure_scraper_base_url", _base_url, raising=True)
+    tasks.embed_from_scraper_task.request.id = "task-embed"
+
+    class FakeCache:
+        def get_res_ids(self) -> list[int]:
+            return [101, 202]
+
+    class DummyClient:
+        def __enter__(self) -> DummyClient:
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+        def download_inside_cv(self, res_id: int) -> bytes:
+            return f"docx-{res_id}".encode()
+
+    class DummyExtractor:
+        def __init__(self, dictionary: object) -> None:
+            self.calls: list[object] = []
+
+        def extract(self, parsed_cv: object) -> str:
+            self.calls.append(parsed_cv)
+            return "skill-result"
+
+    class DummyPipeline:
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, str]] = []
+
+        def process_cv(self, parsed_cv: object, skill_result: str) -> dict[str, int]:
+            self.calls.append((parsed_cv, skill_result))
+            return {"cv_skills": 1, "cv_experiences": 0, "total": 1}
+
+    pipeline = DummyPipeline()
+    extractor = DummyExtractor(dictionary={})
+    states: list[dict[str, Any]] = []
+
+    def _update_state(*, state: str, meta: dict[str, Any]) -> None:
+        states.append({"state": state, "meta": meta})
+
+    def _load_dict(*_: object) -> dict:
+        return {}
+
+    def _make_extractor(_: object) -> DummyExtractor:
+        return extractor
+
+    def _make_pipeline() -> DummyPipeline:
+        return pipeline
+
+    def _parse_docx_bytes(data: bytes, res_id: int) -> tuple[bytes, int]:
+        return data, res_id
+
+    monkeypatch.setattr(tasks, "ScraperResIdCache", FakeCache, raising=True)
+    monkeypatch.setattr(tasks, "ScraperClient", DummyClient, raising=True)
+    monkeypatch.setattr(tasks, "load_skill_dictionary", _load_dict, raising=True)
+    monkeypatch.setattr(tasks, "SkillExtractor", _make_extractor, raising=True)
+    monkeypatch.setattr(tasks, "EmbeddingPipeline", _make_pipeline, raising=True)
+    monkeypatch.setattr(tasks, "parse_docx_bytes", _parse_docx_bytes, raising=True)
+    monkeypatch.setattr(tasks.embed_from_scraper_task, "update_state", _update_state, raising=True)
+
+    result = tasks.embed_from_scraper_task.run()
+
+    assert result["processed"] == 2
+    assert result["failed"] == 0
+    assert result["totals"]["total"] == 2
+    assert pipeline.calls
+    assert states[-1]["meta"]["processed"] == 2
+    assert states[-1]["meta"]["failed"] == 0
+
+
+def test_embed_from_scraper_task__continues_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _base_url() -> str:
+        return "https://scraper"
+
+    monkeypatch.setattr(tasks, "_ensure_scraper_base_url", _base_url, raising=True)
+
+    class FakeCache:
+        def get_res_ids(self) -> list[int]:
+            return [1, 2, 3]
+
+    class DummyClient:
+        def __enter__(self) -> DummyClient:
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+        def download_inside_cv(self, res_id: int) -> bytes:
+            if res_id == 2:
+                raise RuntimeError("boom")
+            return f"docx-{res_id}".encode()
+
+    class DummyExtractor:
+        def __init__(self, dictionary: object) -> None:
+            return None
+
+        def extract(self, parsed_cv: object) -> str:
+            return "skill-result"
+
+    class DummyPipeline:
+        def process_cv(self, parsed_cv: object, skill_result: str) -> dict[str, int]:
+            return {"cv_skills": 1, "cv_experiences": 0, "total": 1}
+
+    def _load_dict(*_: object) -> dict:
+        return {}
+
+    def _make_extractor(_: object) -> DummyExtractor:
+        return DummyExtractor({})
+
+    def _parse_docx_bytes(data: bytes, res_id: int) -> tuple[bytes, int]:
+        return data, res_id
+
+    monkeypatch.setattr(tasks, "ScraperResIdCache", FakeCache, raising=True)
+    monkeypatch.setattr(tasks, "ScraperClient", DummyClient, raising=True)
+    monkeypatch.setattr(tasks, "load_skill_dictionary", _load_dict, raising=True)
+    monkeypatch.setattr(tasks, "SkillExtractor", _make_extractor, raising=True)
+    monkeypatch.setattr(tasks, "EmbeddingPipeline", DummyPipeline, raising=True)
+    monkeypatch.setattr(tasks, "parse_docx_bytes", _parse_docx_bytes, raising=True)
+
+    result = tasks.embed_from_scraper_task.run()
+
+    assert result["processed"] == 2
+    assert result["failed"] == 1
+    assert result["errors"][0]["res_id"] == 2

--- a/tests/test_cv_parser.py
+++ b/tests/test_cv_parser.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import shutil
+from io import BytesIO
 from pathlib import Path
 
 import pytest
 from docx import Document
 
-from src.core.parser.docx_parser import CVParseError, parse_docx
+from src.core.parser.docx_parser import CVParseError, parse_docx, parse_docx_bytes
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "sample_cvs"
 
@@ -60,6 +61,24 @@ def test_parse_invalid_docx_raises(tmp_path: Path) -> None:
 
     with pytest.raises(CVParseError):
         parse_docx(invalid_path)
+
+
+def test_parse_docx_bytes__valid_docx__returns_parsed_cv() -> None:
+    document = Document()
+    document.add_paragraph("Test CV")
+    buffer = BytesIO()
+    document.save(buffer)
+
+    parsed = parse_docx_bytes(buffer.getvalue(), 12345)
+
+    assert parsed.metadata.res_id == 12345
+    assert parsed.metadata.file_name == "12345_unknown.docx"
+    assert "Test CV" in parsed.raw_text
+
+
+def test_parse_docx_bytes__invalid_docx__raises_parse_error() -> None:
+    with pytest.raises(CVParseError):
+        parse_docx_bytes(b"not a docx file", 12345)
 
 
 def test_parse_docx__filename_with_res_id__sets_metadata_res_id(tmp_path: Path) -> None:

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.core.embedding.pipeline import EmbeddingPipeline
+from src.core.embedding.pipeline import EmbeddingPipeline, _generate_point_id
 from src.core.embedding.service import EmbeddingService
 from src.core.parser.schemas import CVMetadata, ExperienceItem, ParsedCV, SkillSection
 from src.core.skills.schemas import NormalizedSkill, SkillExtractionResult
@@ -347,3 +347,8 @@ def test_process_cv__experience_years_handles_current_date() -> None:
     experience_years = cv_exp_points[0].payload["experience_years"]
     assert experience_years is not None
     assert experience_years >= 0
+
+
+def test_generate_point_id__same_inputs__returns_stable_id() -> None:
+    assert _generate_point_id("cv-123", "skills") == "cv-123_skills"
+    assert _generate_point_id("cv-123", "skills") == "cv-123_skills"

--- a/tests/test_scraper_client.py
+++ b/tests/test_scraper_client.py
@@ -190,3 +190,38 @@ def test_http_status_error__propagates_httpx_status_error() -> None:
     with pytest.raises(httpx.HTTPStatusError):
         with client:
             client.export_availability_csv()
+
+
+def test_download_inside_cv__returns_bytes() -> None:
+    payload = b"docx-bytes"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/inside/cv/123"
+        return httpx.Response(200, content=payload)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with client:
+        result = client.download_inside_cv(123)
+
+    assert result == payload
+
+
+def test_download_inside_cv__http_status_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = ScraperClient(
+        config=ScraperClientConfig(base_url="https://scraper"),
+        transport=transport,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        with client:
+            client.download_inside_cv(123)

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import pytest
 
+from src.core.workflows.loader import load_workflow
 from src.core.workflows.runner import WorkflowRunner
 from src.core.workflows.schemas import FanoutConfig, WorkflowDefinition, WorkflowNode
+
+
+def _collect_task_names(signature: Any) -> list[str]:
+    tasks = getattr(signature, "tasks", None)
+    if tasks is not None:
+        names: list[str] = []
+        for task in tasks:
+            names.extend(_collect_task_names(task))
+        return names
+    task_name = getattr(signature, "task", None)
+    if isinstance(task_name, str):
+        return [task_name]
+    return []
 
 
 def test_build_canvas__linear_dependencies__creates_chain() -> None:
@@ -57,3 +74,16 @@ def test_build_canvas__fanout_node__adds_fanout_kwargs() -> None:
     assert canvas.kwargs["fanout_source"] == "redis:cache"
     assert canvas.kwargs["fanout_task"] == "tasks.child"
     assert canvas.kwargs["fanout_parameter_name"] == "res_id"
+
+
+def test_build_canvas__workflow_includes_embed_all_after_fanout() -> None:
+    definition = load_workflow(Path("config/workflows/res_id_workflow.yaml"))
+
+    canvas = WorkflowRunner().build_canvas(definition)
+
+    body = getattr(canvas, "body", None)
+    assert body is not None
+    task_names = _collect_task_names(body)
+    fanout_index = task_names.index("src.services.workflows.tasks.run_workflow_fanout_task")
+    embed_index = task_names.index("src.services.embedding.tasks.embed_from_scraper_task")
+    assert embed_index > fanout_index


### PR DESCRIPTION
## Summary
- Add binary CV download to scraper client and in-memory DOCX parsing
- Add scraper-driven embedding task with progress tracking and resilience
- Wire `embed_all` node into ingestion workflow and add `make embed-all`
- Add tests for downloader, parser bytes, embedding task, idempotent IDs, and workflow canvas
- Update backlog entry for TD-005 status

## Related Issue
Closes #57

## Testing
- `make test`