### PR TITLE
[US-013] Dedicated Celery queues per workload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 	@echo ""
 	@echo "Run:"
 	@echo "  make run                     Start the API server"
-	@echo "  make worker                  Start Celery worker"
+	@echo "  make worker                  Start Celery workers (dedicated queues)"
 	@echo "  make beat                    Start Celery beat scheduler"
 	@echo "  make flower                  Start Flower dashboard"
 	@echo "  make embed-all               Trigger embedding from scraper"
@@ -53,7 +53,7 @@ help:
 	@echo "  make <service>-build         Build a single service image (no start)"
 	@echo "  make <service>-rebuild       Build + recreate a single service"
 	@echo "  make <service>-logs          Tail logs for a single service (follow)"
-	@echo "  services: qdrant redis api celery-worker celery-beat flower prometheus grafana redis-exporter celery-exporter"
+	@echo "  services: qdrant redis api celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow celery-beat flower prometheus grafana redis-exporter celery-exporter"
 	@echo "  make system                  Dev mode: infra in Docker + app local (uv run)"
 	@echo "  make system-down             Stop dev mode (infra + local processes)"
 	@echo ""
@@ -152,8 +152,8 @@ run:
 	uv run uvicorn src.api.main:app --reload --host 0.0.0.0 --port 8000
 
 worker:
-	@echo "🧵 Starting Celery worker..."
-	uv run celery -A src.services.embedding.celery_app worker -l info -c 4
+	@echo "🧵 Starting Celery workers..."
+	$(COMPOSE) --profile full up -d celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 beat:
 	@echo "⏲️ Starting Celery beat..."
@@ -210,6 +210,14 @@ all-down:
 all-logs:
 	@echo "📄 Tailing ALL logs..."
 	$(COMPOSE) --profile full --profile monitoring logs -f --tail=200
+
+memory-probe-logs:
+	@echo "📄 Tailing memory probe logs..."
+	$(COMPOSE) --profile full logs -f --tail=200 api celery-worker-embedding | grep --line-buffered "memory_probe"
+
+workflow-run:
+	@echo "🚀 Triggering main ingestion workflow..."
+	$(COMPOSE) --profile full exec -T celery-worker-workflow python -c "from src.services.embedding.celery_app import celery_app; result = celery_app.send_task('workflow.run_ingestion'); print('Workflow triggered:', result.id)"
 
 all-rebuild:
 	@echo "♻️ Rebuilding ALL containers..."
@@ -274,23 +282,23 @@ api-logs:
 	$(COMPOSE) --profile full logs -f --tail=200 api
 
 celery-worker-build:
-	$(COMPOSE) --profile full build celery-worker
+	$(COMPOSE) --profile full build celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 celery-worker-create:
-	$(COMPOSE) --profile full create celery-worker
+	$(COMPOSE) --profile full create celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 celery-worker-up:
-	$(COMPOSE) --profile full up -d celery-worker
+	$(COMPOSE) --profile full up -d celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 celery-worker-down:
-	$(COMPOSE) --profile full stop celery-worker
-	$(COMPOSE) --profile full rm -f celery-worker
+	$(COMPOSE) --profile full stop celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
+	$(COMPOSE) --profile full rm -f celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 celery-worker-rebuild:
-	$(COMPOSE) --profile full up -d --build --force-recreate celery-worker
+	$(COMPOSE) --profile full up -d --build --force-recreate celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 celery-worker-logs:
-	$(COMPOSE) --profile full logs -f --tail=200 celery-worker
+	$(COMPOSE) --profile full logs -f --tail=200 celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 
 celery-beat-build:
 	$(COMPOSE) --profile full build celery-beat
@@ -408,15 +416,14 @@ celery-exporter-logs:
 
 queues-clean:
 	@echo "🧹 Cleaning Redis + Celery queues..."
-	@ACTIVE_IDS=$$(docker exec profilebot-celery-worker celery -A src.services.embedding.celery_app inspect active --json | python -c 'import json,sys; data=json.load(sys.stdin); ids=[]; [ids.extend([t.get("id") for t in tasks if t.get("id")]) for tasks in data.values() if isinstance(tasks, list)]; print(" ".join(ids))'); \
-	if [ -n "$$ACTIVE_IDS" ]; then \
-		docker exec profilebot-celery-worker celery -A src.services.embedding.celery_app control revoke $$ACTIVE_IDS; \
-		docker exec profilebot-celery-worker celery -A src.services.embedding.celery_app control terminate SIGTERM $$ACTIVE_IDS; \
-	else \
-		echo "No active tasks to revoke"; \
-	fi
-	@docker exec profilebot-celery-worker celery -A src.services.embedding.celery_app purge -f
+	@$(COMPOSE) --profile full stop celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
+	@$(COMPOSE) --profile full run --rm celery-worker-embedding celery -A src.services.embedding.celery_app purge -f -Q embedding
+	@$(COMPOSE) --profile full run --rm celery-worker-embedding celery -A src.services.embedding.celery_app purge -f -Q ingestion
+	@$(COMPOSE) --profile full run --rm celery-worker-embedding celery -A src.services.embedding.celery_app purge -f -Q scraper
+	@$(COMPOSE) --profile full run --rm celery-worker-embedding celery -A src.services.embedding.celery_app purge -f -Q availability
+	@$(COMPOSE) --profile full run --rm celery-worker-embedding celery -A src.services.embedding.celery_app purge -f -Q workflow
 	@docker exec profilebot-redis redis-cli FLUSHALL
+	@$(COMPOSE) --profile full up -d celery-worker-embedding celery-worker-ingestion celery-worker-scraper celery-worker-availability celery-worker-workflow
 	@echo "✅ Done"
 
 queues-clean-all: queues-clean
@@ -425,7 +432,7 @@ system: qdrant-up redis-up
 	@echo "🚀 Starting full ProfileBot stack in background..."
 	@mkdir -p .logs
 	@sh -c 'nohup uv run uvicorn src.api.main:app --reload --host 0.0.0.0 --port 8000 > .logs/api.log 2>&1 & echo $$! > .logs/api.pid'
-	@sh -c 'nohup uv run celery -A src.services.embedding.celery_app worker -l info -c 4 > .logs/worker.log 2>&1 & echo $$! > .logs/worker.pid'
+	@sh -c 'nohup uv run celery -A src.services.embedding.celery_app worker -l info -Q embedding,ingestion,scraper,availability,workflow -c 4 > .logs/worker.log 2>&1 & echo $$! > .logs/worker.pid'
 	@sh -c 'nohup uv run celery -A src.services.embedding.celery_app beat -l info > .logs/beat.log 2>&1 & echo $$! > .logs/beat.pid'
 	@sh -c 'nohup uv run celery -A src.services.embedding.celery_app flower --port=5555 > .logs/flower.log 2>&1 & echo $$! > .logs/flower.pid'
 	@echo "✅ Started. Logs in .logs/*.log, PIDs in .logs/*.pid"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,13 +52,118 @@ services:
       - profilebot
     restart: unless-stopped
 
-  celery-worker:
+  # Worker dedicato embedding — concorrenza bassa (CPU+network OpenAI)
+  celery-worker-embedding:
     profiles: ["full"]
     build: .
-    container_name: profilebot-celery-worker
+    container_name: profilebot-celery-worker-embedding
     working_dir: /app
     user: "1000:1000"
-    command: celery -A src.services.embedding.celery_app worker -l info -c ${CELERY_WORKER_CONCURRENCY:-4} -E
+    command: celery -A src.services.embedding.celery_app worker -l info -Q embedding -c ${CELERY_CONCURRENCY_EMBEDDING:-2} -E
+    volumes:
+      - ./:/app
+    env_file: .env
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - QDRANT_URL=http://qdrant:6333
+      - SCRAPER_BASE_URL=http://scraper-service:8001
+    extra_hosts:
+      - "scraper-service:host-gateway"
+    depends_on:
+      - redis
+      - qdrant
+    networks:
+      - profilebot
+    restart: unless-stopped
+
+  # Worker dedicato ingestion — HTTP leggero, deve restare reattivo
+  celery-worker-ingestion:
+    profiles: ["full"]
+    build: .
+    container_name: profilebot-celery-worker-ingestion
+    working_dir: /app
+    user: "1000:1000"
+    command: celery -A src.services.embedding.celery_app worker -l info -Q ingestion -c ${CELERY_CONCURRENCY_INGESTION:-4} -E
+    volumes:
+      - ./:/app
+    env_file: .env
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - QDRANT_URL=http://qdrant:6333
+      - SCRAPER_BASE_URL=http://scraper-service:8001
+    extra_hosts:
+      - "scraper-service:host-gateway"
+    depends_on:
+      - redis
+      - qdrant
+    networks:
+      - profilebot
+    restart: unless-stopped
+
+  # Worker dedicato scraper — I/O bound, concorrenza più alta
+  celery-worker-scraper:
+    profiles: ["full"]
+    build: .
+    container_name: profilebot-celery-worker-scraper
+    working_dir: /app
+    user: "1000:1000"
+    command: celery -A src.services.embedding.celery_app worker -l info -Q scraper -c ${CELERY_CONCURRENCY_SCRAPER:-4} -E
+    volumes:
+      - ./:/app
+    env_file: .env
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - QDRANT_URL=http://qdrant:6333
+      - SCRAPER_BASE_URL=http://scraper-service:8001
+    extra_hosts:
+      - "scraper-service:host-gateway"
+    depends_on:
+      - redis
+      - qdrant
+    networks:
+      - profilebot
+    restart: unless-stopped
+
+  # Worker dedicato availability — task periodici, non urgenti
+  celery-worker-availability:
+    profiles: ["full"]
+    build: .
+    container_name: profilebot-celery-worker-availability
+    working_dir: /app
+    user: "1000:1000"
+    command: celery -A src.services.embedding.celery_app worker -l info -Q availability -c ${CELERY_CONCURRENCY_AVAILABILITY:-2} -E
+    volumes:
+      - ./:/app
+    env_file: .env
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - QDRANT_URL=http://qdrant:6333
+      - SCRAPER_BASE_URL=http://scraper-service:8001
+    extra_hosts:
+      - "scraper-service:host-gateway"
+    depends_on:
+      - redis
+      - qdrant
+    networks:
+      - profilebot
+    restart: unless-stopped
+
+  # Worker dedicato workflow — orchestrazione, non fa lavoro pesante
+  celery-worker-workflow:
+    profiles: ["full"]
+    build: .
+    container_name: profilebot-celery-worker-workflow
+    working_dir: /app
+    user: "1000:1000"
+    command: celery -A src.services.embedding.celery_app worker -l info -Q workflow -c ${CELERY_CONCURRENCY_WORKFLOW:-2} -E
     volumes:
       - ./:/app
     env_file: .env
@@ -92,7 +197,6 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
     depends_on:
       - redis
-      - celery-worker
     networks:
       - profilebot
     restart: unless-stopped
@@ -114,7 +218,6 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
     depends_on:
       - redis
-      - celery-worker
     networks:
       - profilebot
     restart: unless-stopped

--- a/src/services/embedding/celery_app.py
+++ b/src/services/embedding/celery_app.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from celery import Celery
 from celery.schedules import crontab
+from kombu import Queue
 
 from src.core.config import get_settings
 from src.core.workflows.loader import load_workflow
@@ -68,6 +69,20 @@ celery_app.conf.update(
     result_expires=settings.celery_result_expires,
     worker_prefetch_multiplier=4,
     worker_concurrency=settings.celery_worker_concurrency,
+    task_routes={
+        "embedding.*": {"queue": "embedding"},
+        "ingestion.*": {"queue": "ingestion"},
+        "scraper.*": {"queue": "scraper"},
+        "availability.*": {"queue": "availability"},
+        "workflow.*": {"queue": "workflow"},
+    },
+    task_queues=(
+        Queue("embedding"),
+        Queue("ingestion"),
+        Queue("scraper"),
+        Queue("availability"),
+        Queue("workflow"),
+    ),
     beat_schedule={
         "availability-refresh": {
             "task": "availability.refresh_cache",


### PR DESCRIPTION
## Description\n- Split Celery workers by queue in docker-compose (embedding/ingestion/scraper/availability/workflow)\n- Add task routes + queues in Celery config\n- Update Makefile targets to manage dedicated workers\n\n## Related Issue\n- N/A (US-013 Celery queue refinement)\n\n## Type of Change\n- Refactoring / Ops\n\n## Checklist\n- [x] Linting (pre-commit: ruff, ruff-format, mypy, bandit)\n- [ ] Tests (not run)\n\n## Testing\n- Not run