### PR TITLE
[US-93] Async Qdrant upserts in process_cv

### DIFF
--- a/src/core/embedding/pipeline.py
+++ b/src/core/embedding/pipeline.py
@@ -109,21 +109,21 @@ class EmbeddingPipeline:
             self._qdrant_client.upsert(
                 collection_name="cv_skills",
                 points=skills_points,
-                wait=True,
+                wait=False,  # eventual consistency OK
             )
 
         if experience_points:
             self._qdrant_client.upsert(
                 collection_name="cv_experiences",
                 points=experience_points,
-                wait=True,
+                wait=False,  # eventual consistency OK
             )
 
         if chunk_points:
             self._qdrant_client.upsert(
                 collection_name="cv_chunks",
                 points=chunk_points,
-                wait=True,
+                wait=False,  # eventual consistency OK
             )
 
         logger.info(

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -228,6 +229,7 @@ def test_pipeline_complete__fetch_fanout_best_effort_embed_search(
     assert embed_result["status"] == "completed"
     assert embed_result["processed"] == len(res_ids)
 
+    time.sleep(0.2)  # eventual consistency — tipicamente < 100ms
     dependencies = SearchDependencies(
         qdrant_client=fake_qdrant,
         embedding_service=DummyEmbeddingService(),

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -179,6 +179,13 @@ def test_process_cv__upsert_counts__includes_all_collections() -> None:
     assert len(calls) == 3
 
 
+def test_process_cv__upsert_uses_wait_false() -> None:
+    _, calls = _run_pipeline_for_upsert()
+
+    waits = [call.kwargs["wait"] for call in calls]
+    assert all(wait is False for wait in waits)
+
+
 def test_process_cv__upsert_payloads__include_skills_fields() -> None:
     _, calls = _run_pipeline_for_upsert()
 


### PR DESCRIPTION
## Description\n- Set Qdrant upserts in process_cv to wait=False with inline rationale\n- Add regression assertion for wait=False in embedding pipeline tests\n- Add eventual-consistency delay before search in e2e pipeline test\n\n## Related Issue\nCloses #93\n\n## Type of Change\n- Refactor\n- Test\n\n## Checklist\n- [x] Linting (pre-commit: ruff, ruff-format, mypy, bandit)\n- [ ] Tests (not run)\n\n## Testing\n- Not run